### PR TITLE
Read modbus data immediatly after connecting

### DIFF
--- a/custom_components/alfen_modbus/__init__.py
+++ b/custom_components/alfen_modbus/__init__.py
@@ -160,6 +160,7 @@ class AlfenModbusHub:
             self._unsub_interval_method = async_track_time_interval(
                 self._hass, self.async_refresh_modbus_data, self._scan_interval
             )
+            self.read_modbus_data()
 
         self._sensors.append(update_callback)
         if refresh_callback is not None:


### PR DESCRIPTION
Hi,

When Home Assistant is restarted, the Alfen sensors are all set to "Unavailable" until the first poll is done some time later.

This small change reads modbus data immediatly after connect so the values are valid from the start.

Frederik