### PR TITLE
Change step of "Max Current Limit" from 1A to 0.1A

### DIFF
--- a/custom_components/alfen_modbus/const.py
+++ b/custom_components/alfen_modbus/const.py
@@ -215,5 +215,5 @@ CONTROL_PHASE = [
 
 
 CONTROL_SLAVE_MAX_CURRENT = [
-    ["Max Current Limit S", MAX_CURRENT_S, 1210, "f", {"min": 0, "max": 32, "unit": "A"}],
+    ["Max Current Limit S", MAX_CURRENT_S, 1210, "f", {"min": 0, "max": 32, "unit": "A", "mode": "slider", "step": 0.1}]
 ]

--- a/custom_components/alfen_modbus/number.py
+++ b/custom_components/alfen_modbus/number.py
@@ -89,6 +89,10 @@ class AlfenNumber(NumberEntity):
         self._attr_native_max_value = attrs["max"]
         if "unit" in attrs.keys():
             self._attr_native_unit_of_measurement = attrs["unit"]
+        if "mode" in attrs.keys():
+            self._attr_mode = attrs["mode"]
+        if "step" in attrs.keys():
+            self._attr_native_step = attrs["step"]
 
     async def async_added_to_hass(self) -> None:
         """Register callbacks."""


### PR DESCRIPTION
Hi,

I'm using this integration to automatically control car charging power via NodeRed (e.g use Solar only)

The current step size of the "Max Current Limit" of 1A (which is 700 Watt when charging using 3 phases) is a bit too big -> this commit changes it to 0.1A.

Could you consider to add this to  your integration?

![current](https://github.com/user-attachments/assets/ce64c97e-4cf5-4cf4-bdda-c7efcb57b625)

thanks,
Frederik