### PR TITLE
Update __init__.py

### DIFF
--- a/custom_components/alfen_modbus/__init__.py
+++ b/custom_components/alfen_modbus/__init__.py
@@ -224,14 +224,14 @@ class AlfenModbusHub:
         """Read holding registers."""
         with self._lock:
             return self._client.read_holding_registers(
-                address=address, count=count, slave=unit
+                address=address, count=count, device_id=unit
             )
 
     def write_registers(self, unit, address, payload):
         """Write registers."""
         with self._lock:
             return self._client.write_registers(
-                address=address, values=payload, slave=unit
+                address=address, values=payload, device_id=unit
             )
             
     def refresh_max_current(self):


### PR DESCRIPTION
Slave is not supported by Pymodbus 3.11.1 any longer. 

Needs to be replaced: slave= -> device_id=