### PR TITLE
Update "usable phases" data when reading modbus

### DIFF
--- a/custom_components/alfen_modbus/__init__.py
+++ b/custom_components/alfen_modbus/__init__.py
@@ -28,6 +28,7 @@ from .const import (
     DEFAULT_READ_SOCKET2,
     VALID_TIME_S,
     MAX_CURRENT_S,
+    CONTROL_PHASE_MODES
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -376,6 +377,9 @@ class AlfenModbusHub:
             if "socket_"+str(socket)+"_chargingStartWh" in self.data and "socket_"+str(socket)+"_chargingStart" in self.data and self.data["socket_"+str(socket)+"_carcharging"] == 1:     
                 self.data["socket_"+str(socket)+"_currentSession"] = self.data["socket_"+str(socket)+"_realEnergyDeliveredSum"] - self.data["socket_"+str(socket)+"_chargingStartWh"]               
                 self.data["socket_"+str(socket)+"_currentSessionDuration"] = self.data["stationTime"] - self.data["socket_"+str(socket)+"_chargingStart"]
+
+            if self.data["socket_"+str(socket)+"_chargephases"] in CONTROL_PHASE_MODES:
+                self.data["usephases_S"+str(socket)] = CONTROL_PHASE_MODES[self.data["socket_"+str(socket)+"_chargephases"]]
         return True           
         
         


### PR DESCRIPTION
Hi,

Here is my next small improvement.

With current code, the "Usable phases" select has no value unless it is set from Home Assistant.

![usable_phases_before](https://github.com/user-attachments/assets/662b81ba-c36d-4a68-a837-0be63a91e66d)

This small changes makes sure it gets the up to date value read via modbus.

![usable_phases_after](https://github.com/user-attachments/assets/3fa1a20c-08f6-434a-83d7-7ee54b24645e)

regards,
Frederik
