### PR TITLE
fix: mark integration as device-based

### DIFF
--- a/custom_components/alfen_modbus/manifest.json
+++ b/custom_components/alfen_modbus/manifest.json
@@ -8,7 +8,7 @@
   "config_flow": true,
   "dependencies": [],
   "documentation": "https://github.com/ThaStealth/alfen_modbus",  
-  "integration_type": "hub",
+  "integration_type": "device",
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/ThaStealth/alfen_modbus/issues",
   "requirements": [


### PR DESCRIPTION
Change from hub-based to device-based integration.

<img width="906" height="340" alt="Bildschirmfoto 2026-06-18 um 16 43 02" src="https://github.com/user-attachments/assets/3b4d061a-9a7c-49e7-84ed-5244542e70dd" />
