### PR TITLE
fix: use config entry runtime data

### DIFF
--- a/custom_components/alfen_modbus/__init__.py
+++ b/custom_components/alfen_modbus/__init__.py
@@ -54,6 +54,8 @@ CONFIG_SCHEMA = vol.Schema(
 
 PLATFORMS = ["binary_sensor", "number", "select", "sensor"]
 
+type AlfenConfigEntry = ConfigEntry[AlfenModbusHub]
+
 
 async def async_setup(hass, config):
     """Set up the Alfen modbus component."""
@@ -61,7 +63,7 @@ async def async_setup(hass, config):
     return True
 
 
-async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
+async def async_setup_entry(hass: HomeAssistant, entry: AlfenConfigEntry):
     """Set up a alfen mobus."""
     host = entry.data[CONF_HOST]
     name = entry.data[CONF_NAME]
@@ -84,7 +86,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
         read_socket2
     )
     """Register the hub."""
-    hass.data[DOMAIN][name] = {"hub": hub}
+    entry.runtime_data = hub
 
     # Read device info before setting up platforms so device_info is available
     hub.connect()
@@ -92,7 +94,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     return True
-
 
 
 async def async_unload_entry(hass, entry):

--- a/custom_components/alfen_modbus/binary_sensor.py
+++ b/custom_components/alfen_modbus/binary_sensor.py
@@ -9,6 +9,7 @@ from homeassistant.components.binary_sensor import (
 from homeassistant.const import CONF_NAME
 from homeassistant.core import callback
 
+from . import AlfenConfigEntry
 from .const import DOMAIN, ATTR_MANUFACTURER
 
 _LOGGER = logging.getLogger(__name__)
@@ -18,11 +19,10 @@ BINARY_SENSOR_TYPES = [
     ["Car Charging", "carcharging", BinarySensorDeviceClass.BATTERY_CHARGING, "mdi:battery-charging", "mdi:battery-off"],
 ]
 
-
-async def async_setup_entry(hass, entry, async_add_entities) -> None:
+async def async_setup_entry(hass, entry: AlfenConfigEntry, async_add_entities) -> None:
     """Set up Alfen binary sensors."""
     hub_name = entry.data[CONF_NAME]
-    hub = hass.data[DOMAIN][hub_name]["hub"]
+    hub = entry.runtime_data
 
     device_info = {
         "identifiers": {(DOMAIN, hub_name)},

--- a/custom_components/alfen_modbus/number.py
+++ b/custom_components/alfen_modbus/number.py
@@ -6,12 +6,12 @@ from homeassistant.const import CONF_NAME
 from homeassistant.core import callback
 
 from . import AlfenConfigEntry
-from .entity import AlfenEntity
 from .const import (
     DOMAIN,
     ATTR_MANUFACTURER,
     CONTROL_SLAVE_MAX_CURRENT,
 )
+from .entity import AlfenEntity
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/alfen_modbus/number.py
+++ b/custom_components/alfen_modbus/number.py
@@ -1,22 +1,22 @@
 import logging
 from typing import Optional, Dict, Any
 
+from homeassistant.components.number import NumberEntity
+from homeassistant.const import CONF_NAME
+from homeassistant.core import callback
+
+from . import AlfenConfigEntry
 from .const import (
     DOMAIN,
     ATTR_MANUFACTURER,
     CONTROL_SLAVE_MAX_CURRENT,
 )
 
-from homeassistant.const import CONF_NAME
-from homeassistant.components.number import NumberEntity
-
-from homeassistant.core import callback
-
 _LOGGER = logging.getLogger(__name__)
 
-async def async_setup_entry(hass, entry, async_add_entities) -> None:
+async def async_setup_entry(hass, entry: AlfenConfigEntry, async_add_entities) -> None:
     hub_name = entry.data[CONF_NAME]
-    hub = hass.data[DOMAIN][hub_name]["hub"]
+    hub = entry.runtime_data
 
     device_info = {
         "identifiers": {(DOMAIN, hub_name)},

--- a/custom_components/alfen_modbus/select.py
+++ b/custom_components/alfen_modbus/select.py
@@ -1,6 +1,11 @@
 import logging
 from typing import Optional, Dict, Any
 
+from homeassistant.components.select import SelectEntity
+from homeassistant.const import CONF_NAME
+from homeassistant.core import callback
+
+from . import AlfenConfigEntry
 from .const import (
     DOMAIN,
     ATTR_MANUFACTURER,
@@ -8,16 +13,11 @@ from .const import (
     CONTROL_PHASE_MODES,
 )
 
-from homeassistant.const import CONF_NAME
-from homeassistant.components.select import SelectEntity
-
-from homeassistant.core import callback
-
 _LOGGER = logging.getLogger(__name__)
 
-async def async_setup_entry(hass, entry, async_add_entities) -> None:
+async def async_setup_entry(hass, entry: AlfenConfigEntry, async_add_entities) -> None:
     hub_name = entry.data[CONF_NAME]
-    hub = hass.data[DOMAIN][hub_name]["hub"]
+    hub = entry.runtime_data
 
     device_info = {
         "identifiers": {(DOMAIN, hub_name)},

--- a/custom_components/alfen_modbus/sensor.py
+++ b/custom_components/alfen_modbus/sensor.py
@@ -23,12 +23,14 @@ from homeassistant.components.sensor import (
 
 from homeassistant.core import callback
 
+from . import AlfenConfigEntry
+
 _LOGGER = logging.getLogger(__name__)
 
 
-async def async_setup_entry(hass, entry, async_add_entities):
+async def async_setup_entry(hass, entry: AlfenConfigEntry, async_add_entities):
     hub_name = entry.data[CONF_NAME]
-    hub = hass.data[DOMAIN][hub_name]["hub"]
+    hub = entry.runtime_data
     
     device_info = {
         "identifiers": {(DOMAIN, hub_name)},


### PR DESCRIPTION
Implemeting IQS rule [runtime_data](https://developers.home-assistant.io/docs/core/integration-quality-scale/rules/runtime-data)