### PR TITLE
feat: use common entity type

### DIFF
--- a/custom_components/alfen_modbus/binary_sensor.py
+++ b/custom_components/alfen_modbus/binary_sensor.py
@@ -10,6 +10,7 @@ from homeassistant.const import CONF_NAME
 from homeassistant.core import callback
 
 from .const import DOMAIN, ATTR_MANUFACTURER
+from .entity import AlfenEntity
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -69,7 +70,7 @@ async def async_setup_entry(hass, entry, async_add_entities) -> None:
     return True
 
 
-class AlfenBinarySensor(BinarySensorEntity):
+class AlfenBinarySensor(AlfenEntity, BinarySensorEntity):
     """Representation of an Alfen Modbus binary sensor."""
 
     def __init__(
@@ -85,27 +86,14 @@ class AlfenBinarySensor(BinarySensorEntity):
         icon_off,
     ) -> None:
         """Initialize the binary sensor."""
+        super().__init__(hub, device_info)
         self._platform_name = platform_name
-        self._hub = hub
         self._socket = socket
         self._name = f"S{socket} {name}" if hub.has_socket_2 else name
         self._key = f"socket_{socket}_{key}"
         self._attr_device_class = device_class
         self._icon_on = icon_on
         self._icon_off = icon_off
-
-    async def async_added_to_hass(self) -> None:
-        """Register callbacks."""
-        self._hub.async_add_alfen_sensor(self._modbus_data_updated)
-
-    async def async_will_remove_from_hass(self) -> None:
-        """Remove callbacks."""
-        self._hub.async_remove_alfen_sensor(self._modbus_data_updated)
-
-    @callback
-    def _modbus_data_updated(self) -> None:
-        """Handle updated data from the hub."""
-        self.async_write_ha_state()
 
     @property
     def name(self) -> str:
@@ -128,19 +116,3 @@ class AlfenBinarySensor(BinarySensorEntity):
     def icon(self) -> str:
         """Return the icon based on state."""
         return self._icon_on if self.is_on else self._icon_off
-
-    @property
-    def should_poll(self) -> bool:
-        """Data is delivered by the hub."""
-        return False
-
-    @property
-    def device_info(self) -> Optional[Dict[str, Any]]:
-        """Return device info."""
-        return {
-            "identifiers": {(DOMAIN, self._platform_name)},
-            "name": self._hub.data.get("name", self._platform_name),
-            "manufacturer": ATTR_MANUFACTURER,
-            "model": self._hub.data.get("platformType", "Unknown"),
-            "sw_version": self._hub.data.get("firmwareVersion", "Unknown"),
-        }

--- a/custom_components/alfen_modbus/entity.py
+++ b/custom_components/alfen_modbus/entity.py
@@ -1,7 +1,7 @@
 """Entities for the Alfen Modbus integration."""
 
-from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.core import callback
+from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity import Entity, EntityDescription
 
 from . import AlfenModbusHub

--- a/custom_components/alfen_modbus/entity.py
+++ b/custom_components/alfen_modbus/entity.py
@@ -1,0 +1,36 @@
+"""Entities for the Alfen Modbus integration."""
+
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.core import callback
+from homeassistant.helpers.entity import Entity, EntityDescription
+
+from . import AlfenModbusHub
+
+
+class AlfenEntity(Entity):
+    """Representation of an Alfen Modbus entity."""
+
+    # _attr_has_entity_name = True
+    _attr_should_poll = False
+
+    def __init__(
+        self,
+        hub: AlfenModbusHub,
+        device_info: DeviceInfo,
+    ) -> None:
+        """Initialize the Alfen Modbus entity."""
+        self._hub = hub
+        self._attr_device_info = device_info
+
+    async def async_added_to_hass(self) -> None:
+        """Register callbacks."""
+        self._hub.async_add_alfen_sensor(self._modbus_data_updated)
+
+    async def async_will_remove_from_hass(self) -> None:
+        """Remove callbacks."""
+        self._hub.async_remove_alfen_sensor(self._modbus_data_updated)
+
+    @callback
+    def _modbus_data_updated(self) -> None:
+        """Handle updated data from the hub."""
+        self.async_write_ha_state()

--- a/custom_components/alfen_modbus/number.py
+++ b/custom_components/alfen_modbus/number.py
@@ -12,6 +12,8 @@ from homeassistant.components.number import NumberEntity
 
 from homeassistant.core import callback
 
+from .entity import AlfenEntity
+
 _LOGGER = logging.getLogger(__name__)
 
 async def async_setup_entry(hass, entry, async_add_entities) -> None:
@@ -74,9 +76,9 @@ class AlfenNumber(NumberEntity):
                  fmt,
                  attrs
     ) -> None:
-        """Initialize the selector."""
+        """Initialize the number."""
+        super().__init__(hub, device_info)
         self._platform_name = platform_name
-        self._hub = hub
         self._name = name+str(socket)
         self._socket = socket
         self._key = key+str(socket)
@@ -93,14 +95,10 @@ class AlfenNumber(NumberEntity):
 
     async def async_added_to_hass(self) -> None:
         """Register callbacks."""
-        self._hub.async_add_alfen_sensor(self._modbus_data_updated,self.update_value)
+        self._hub.async_add_alfen_sensor(self._modbus_data_updated, self.update_value)
 
     async def async_will_remove_from_hass(self) -> None:
-        self._hub.async_remove_alfen_sensor(self._modbus_data_updated,self.update_value)
-
-    @callback
-    def _modbus_data_updated(self) -> None:
-        self.async_write_ha_state()
+        self._hub.async_remove_alfen_sensor(self._modbus_data_updated, self.update_value)
 
     @property
     def name(self) -> str:
@@ -110,11 +108,6 @@ class AlfenNumber(NumberEntity):
     @property
     def unique_id(self) -> Optional[str]:
         return f"{self._platform_name}_{self._key}"
-
-    @property
-    def should_poll(self) -> bool:
-        """Data is delivered by the hub"""
-        return False
 
     @property
     def native_value(self) -> float:
@@ -157,13 +150,3 @@ class AlfenNumber(NumberEntity):
         await self.update_value()       
         self.hass.async_create_task(self._hub.async_refresh_modbus_data())
         self.async_write_ha_state()
-
-    @property
-    def device_info(self) -> Optional[Dict[str, Any]]:
-        return {
-            "identifiers": {(DOMAIN, self._platform_name)},
-            "name": self._hub.data.get("name", self._platform_name),
-            "manufacturer": ATTR_MANUFACTURER,
-            "model": self._hub.data.get("platformType", "Unknown"),
-            "sw_version": self._hub.data.get("firmwareVersion", "Unknown"),
-        }

--- a/custom_components/alfen_modbus/select.py
+++ b/custom_components/alfen_modbus/select.py
@@ -13,6 +13,8 @@ from homeassistant.components.select import SelectEntity
 
 from homeassistant.core import callback
 
+from .entity import AlfenEntity
+
 _LOGGER = logging.getLogger(__name__)
 
 async def async_setup_entry(hass, entry, async_add_entities) -> None:
@@ -67,7 +69,7 @@ def get_key(my_dict, search):
             return k
     return None
 
-class AlfenSelect(SelectEntity):
+class AlfenSelect(AlfenEntity, SelectEntity):
     """Representation of an Alfen Modbus select."""
 
     def __init__(self,
@@ -81,6 +83,7 @@ class AlfenSelect(SelectEntity):
                  options
     ) -> None:
         """Initialize the selector."""
+        super().__init__(hub, device_info)
         self._platform_name = platform_name
         self._hub = hub
         self._name = name+str(socket)
@@ -90,17 +93,6 @@ class AlfenSelect(SelectEntity):
         self._option_dict = options
         self._attr_options = list(options.values())
 
-    async def async_added_to_hass(self) -> None:
-        """Register callbacks."""
-        self._hub.async_add_alfen_sensor(self._modbus_data_updated)
-
-    async def async_will_remove_from_hass(self) -> None:
-        self._hub.async_remove_alfen_sensor(self._modbus_data_updated)
-
-    @callback
-    def _modbus_data_updated(self) -> None:
-        self.async_write_ha_state()
-
     @property
     def name(self) -> str:
         """Return the name."""
@@ -109,11 +101,6 @@ class AlfenSelect(SelectEntity):
     @property
     def unique_id(self) -> Optional[str]:
         return f"{self._platform_name}_{self._key}"
-
-    @property
-    def should_poll(self) -> bool:
-        """Data is delivered by the hub"""
-        return False
 
     @property
     def current_option(self) -> str:
@@ -128,13 +115,3 @@ class AlfenSelect(SelectEntity):
         self._hub.data[self._key] = option
         self.hass.async_create_task(self._hub.async_refresh_modbus_data())
         self.async_write_ha_state()
-
-    @property
-    def device_info(self) -> Optional[Dict[str, Any]]:
-        return {
-            "identifiers": {(DOMAIN, self._platform_name)},
-            "name": self._hub.data.get("name", self._platform_name),
-            "manufacturer": ATTR_MANUFACTURER,
-            "model": self._hub.data.get("platformType", "Unknown"),
-            "sw_version": self._hub.data.get("firmwareVersion", "Unknown"),
-        }

--- a/custom_components/alfen_modbus/select.py
+++ b/custom_components/alfen_modbus/select.py
@@ -85,7 +85,6 @@ class AlfenSelect(AlfenEntity, SelectEntity):
         """Initialize the selector."""
         super().__init__(hub, device_info)
         self._platform_name = platform_name
-        self._hub = hub
         self._name = name+str(socket)
         self._socket = socket
         self._key = key+str(socket)

--- a/custom_components/alfen_modbus/sensor.py
+++ b/custom_components/alfen_modbus/sensor.py
@@ -99,6 +99,7 @@ class AlfenSensor(AlfenEntity, SensorEntity):
 
     def __init__(self, platform_name, hub, device_info, name, key, unit, icon):
         """Initialize the sensor."""
+        super().__init__(hub, device_info)
         self._platform_name = platform_name
         self._key = key
         if not hub.has_socket_2:

--- a/custom_components/alfen_modbus/sensor.py
+++ b/custom_components/alfen_modbus/sensor.py
@@ -23,6 +23,8 @@ from homeassistant.components.sensor import (
 
 from homeassistant.core import callback
 
+from .entity import AlfenEntity
+
 _LOGGER = logging.getLogger(__name__)
 
 
@@ -92,13 +94,12 @@ async def async_setup_entry(hass, entry, async_add_entities):
     return True
 
 
-class AlfenSensor(SensorEntity):
+class AlfenSensor(AlfenEntity, SensorEntity):
     """Representation of an Alfen Modbus sensor."""
 
     def __init__(self, platform_name, hub, device_info, name, key, unit, icon):
         """Initialize the sensor."""
         self._platform_name = platform_name
-        self._hub = hub
         self._key = key
         if not hub.has_socket_2:
             if name.startswith("S1 "):
@@ -113,17 +114,6 @@ class AlfenSensor(SensorEntity):
             self._attr_device_class = SensorDeviceClass.ENERGY
         if self._unit_of_measurement == UnitOfPower.WATT :
             self._attr_device_class = SensorDeviceClass.POWER
-
-    async def async_added_to_hass(self) -> None:
-        """Register callbacks."""
-        self._hub.async_add_alfen_sensor(self._modbus_data_updated)
-
-    async def async_will_remove_from_hass(self) -> None:
-        self._hub.async_remove_alfen_sensor(self._modbus_data_updated)
-
-    @callback
-    def _modbus_data_updated(self):
-        self.async_write_ha_state()
 
     @property
     def name(self):
@@ -164,18 +154,3 @@ class AlfenSensor(SensorEntity):
     @property
     def extra_state_attributes(self):         
         return None
-
-    @property
-    def should_poll(self) -> bool:
-        """Data is delivered by the hub"""
-        return False
-
-    @property
-    def device_info(self) -> Optional[Dict[str, Any]]:
-        return {
-            "identifiers": {(DOMAIN, self._platform_name)},
-            "name": self._hub.data.get("name", self._platform_name),
-            "manufacturer": ATTR_MANUFACTURER,
-            "model": self._hub.data.get("platformType", "Unknown"),
-            "sw_version": self._hub.data.get("firmwareVersion", "Unknown"),
-        }


### PR DESCRIPTION
This introduces a common `AlfenEntity` class that handles the `hub` and the `device_info` as well as the `should_poll` attribute.