### PR TITLE
Add AHP support and various problems fixed.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Alfen Modbus for Home Assistant
 
 [![HACS Default](https://img.shields.io/badge/HACS-Default-orange.svg)](https://github.com/hacs/integration)
-[![GitHub Release](https://img.shields.io/github/v/release/straybiker/alfen_modbus)](https://github.com/thastealth/alfen_modbus/releases)
+[![GitHub Release](https://img.shields.io/github/v/release/thastealth/alfen_modbus)](https://github.com/thastealth/alfen_modbus/releases)
 [![License](https://img.shields.io/github/license/thastealth/alfen_modbus)](LICENSE)
 
 Home Assistant integration for **Alfen Eve NG9xx and AHPxx** series EV chargers via Modbus TCP.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![GitHub Release](https://img.shields.io/github/v/release/straybiker/alfen_modbus)](https://github.com/thastealth/alfen_modbus/releases)
 [![License](https://img.shields.io/github/license/thastealth/alfen_modbus)](LICENSE)
 
-Home Assistant integration for **Alfen Eve NG9xx** series EV chargers via Modbus TCP.
+Home Assistant integration for **Alfen Eve NG9xx and AHPxx** series EV chargers via Modbus TCP.
 
 ![Demo](demo.png)
 
@@ -22,9 +22,10 @@ Home Assistant integration for **Alfen Eve NG9xx** series EV chargers via Modbus
 ## Requirements
 
 - Home Assistant **2024.4.0** or newer
-- Alfen Eve NG9xx charger with:
-  - Firmware **4.2.0** or newer (Modbus TCP support)
-  - Firmware **6.4.0+** recommended (fixes power budget reset bug)
+- Alfen Eve (NG9xx or AHPxx) charger with:
+  - (NG9xx) Firmware **4.2.0** or newer (Modbus TCP support)
+  - (NG9xx) Firmware **6.4.0+** recommended (fixes power budget reset bug)
+  - (AHPxx) Firmware **2.6.0+** recommended (Support for Modbus TCP/IP EMS)
   - **Active Load Balancing** license enabled
 - Modbus TCP enabled on the charger
 
@@ -79,7 +80,7 @@ See the [Alfen Smart Charging Manual](https://knowledge.alfen.com/space/IN/63976
 
 ## Known Issues
 
-- Power budget may reset to 0A when no car is connected (fixed in firmware [6.4.0-4210](https://knowledge.alfen.com/space/IN/243466257))
+- Power budget may reset to 0A when no car is connected (fixed in NG9xx firmware [6.4.0-4210](https://knowledge.alfen.com/space/IN/243466257))
 - **Reallin power meter (post-2021)**: Chargers with a Reallin power meter produced after 2021 only export a subset of measurement values. Per-phase energy, apparent energy, and reactive energy sensors will show as "unavailable" (NaN). This is a hardware limitation, not a bug.
 
 ## Contributing

--- a/custom_components/alfen_modbus/__init__.py
+++ b/custom_components/alfen_modbus/__init__.py
@@ -334,7 +334,7 @@ class AlfenModbusHub:
             return False
     
         self.data["actualMaxCurrent"] =  round(self.decode_from_registers(status_data.registers,0,2,self._client.DATATYPE.FLOAT32),2)
-        self.data["boardTemperature"] =  round(self.decode_from_registers(status_data.registers,2,2,self._client.DATATYPE.FLOAT32),2)
+        self.data["boardTemperature"] =  round(self.decode_from_registers(status_data.registers,2,2,self._client.DATATYPE.FLOAT32),3)
         self.data["backofficeConnected"] = self.decode_from_registers(status_data.registers,4,1,self._client.DATATYPE.UINT16)
         self.data["numberOfSockets"] = self.decode_from_registers(status_data.registers,5,1,self._client.DATATYPE.UINT16)
         return True
@@ -352,11 +352,11 @@ class AlfenModbusHub:
         
     async def read_modbus_data_socket(self,socket):
         if((socket == 1) or (socket == 2 and self.has_socket_2 and self.data["numberOfSockets"] >= 2)):
-            energy_data = await self.read_holding_registers(socket,300,125)
+            # Fix for AHP: split socket register reading into two parts as 125 in one go fails on AHP, 
+            # read the first 62 grouped (voltage, current, power) registers, then the last 64 grouped (energy) registers.
+            energy_data = await self.read_holding_registers(socket,300,62)
             if energy_data.isError():
                 return False
-
-
      
             self.data["socket_"+str(socket)+"_meterstate"] =  self.decode_from_registers(energy_data.registers,0,1,self._client.DATATYPE.UINT16)
             self.data["socket_"+str(socket)+"_meterAge"] =  self.decode_from_registers(energy_data.registers,1,4,self._client.DATATYPE.UINT16)
@@ -396,23 +396,27 @@ class AlfenModbusHub:
             self.data["socket_"+str(socket)+"_reactivePowerL3"] =   round(self.decode_from_registers(energy_data.registers,58,2,self._client.DATATYPE.FLOAT32),2)
             self.data["socket_"+str(socket)+"_reactivePowerSum"] =   round(self.decode_from_registers(energy_data.registers,60,2,self._client.DATATYPE.FLOAT32),2)
 
-            self.data["socket_"+str(socket)+"_realEnergyDeliveredL1"] = round(self.decode_from_registers(energy_data.registers,62,4,self._client.DATATYPE.FLOAT64),2) 
-            self.data["socket_"+str(socket)+"_realEnergyDeliveredL2"] =   round(self.decode_from_registers(energy_data.registers,66,4,self._client.DATATYPE.FLOAT64),2) 
-            self.data["socket_"+str(socket)+"_realEnergyDeliveredL3"] =   round(self.decode_from_registers(energy_data.registers,70,4,self._client.DATATYPE.FLOAT64),2) 
-            self.data["socket_"+str(socket)+"_realEnergyDeliveredSum"] =   round(self.decode_from_registers(energy_data.registers,74,4,self._client.DATATYPE.FLOAT64),2) 
-            self.data["socket_"+str(socket)+"_realEnergyConsumedL1"] =  round(self.decode_from_registers(energy_data.registers,78,4,self._client.DATATYPE.FLOAT64),2) 
-            self.data["socket_"+str(socket)+"_realEnergyConsumedL2"] =   round(self.decode_from_registers(energy_data.registers,82,4,self._client.DATATYPE.FLOAT64),2) 
-            self.data["socket_"+str(socket)+"_realEnergyConsumedL3"] =  round(self.decode_from_registers(energy_data.registers,86,4,self._client.DATATYPE.FLOAT64),2) 
-            self.data["socket_"+str(socket)+"_realEnergyConsumedSum"] =   round(self.decode_from_registers(energy_data.registers,90,4,self._client.DATATYPE.FLOAT64),2)     
-            self.data["socket_"+str(socket)+"_apparantEnergyL1"] =  round(self.decode_from_registers(energy_data.registers,92,4,self._client.DATATYPE.FLOAT64),2) 
-            self.data["socket_"+str(socket)+"_apparantEnergyL2"] =   round(self.decode_from_registers(energy_data.registers,96,4,self._client.DATATYPE.FLOAT64),2) 
-            self.data["socket_"+str(socket)+"_apparantEnergyL3"] =  round(self.decode_from_registers(energy_data.registers,100,4,self._client.DATATYPE.FLOAT64),2) 
-            self.data["socket_"+str(socket)+"_apparantEnergySum"] =  round(self.decode_from_registers(energy_data.registers,104,4,self._client.DATATYPE.FLOAT64),2)      
+            # Read the last 64 socket registers
+            energy_data = await self.read_holding_registers(socket,362,64)
+            if energy_data.isError():
+                return False
+            self.data["socket_"+str(socket)+"_realEnergyDeliveredL1"] = round(self.decode_from_registers(energy_data.registers,0,4,self._client.DATATYPE.FLOAT64),2) 
+            self.data["socket_"+str(socket)+"_realEnergyDeliveredL2"] =   round(self.decode_from_registers(energy_data.registers,4,4,self._client.DATATYPE.FLOAT64),2) 
+            self.data["socket_"+str(socket)+"_realEnergyDeliveredL3"] =   round(self.decode_from_registers(energy_data.registers,8,4,self._client.DATATYPE.FLOAT64),2) 
+            self.data["socket_"+str(socket)+"_realEnergyDeliveredSum"] =   round(self.decode_from_registers(energy_data.registers,12,4,self._client.DATATYPE.FLOAT64),2) 
+            self.data["socket_"+str(socket)+"_realEnergyConsumedL1"] =  round(self.decode_from_registers(energy_data.registers,16,4,self._client.DATATYPE.FLOAT64),2) 
+            self.data["socket_"+str(socket)+"_realEnergyConsumedL2"] =   round(self.decode_from_registers(energy_data.registers,20,4,self._client.DATATYPE.FLOAT64),2) 
+            self.data["socket_"+str(socket)+"_realEnergyConsumedL3"] =  round(self.decode_from_registers(energy_data.registers,24,4,self._client.DATATYPE.FLOAT64),2) 
+            self.data["socket_"+str(socket)+"_realEnergyConsumedSum"] =   round(self.decode_from_registers(energy_data.registers,28,4,self._client.DATATYPE.FLOAT64),2)     
+            self.data["socket_"+str(socket)+"_apparantEnergyL1"] =  round(self.decode_from_registers(energy_data.registers,32,4,self._client.DATATYPE.FLOAT64),2) 
+            self.data["socket_"+str(socket)+"_apparantEnergyL2"] =   round(self.decode_from_registers(energy_data.registers,36,4,self._client.DATATYPE.FLOAT64),2) 
+            self.data["socket_"+str(socket)+"_apparantEnergyL3"] =  round(self.decode_from_registers(energy_data.registers,40,4,self._client.DATATYPE.FLOAT64),2) 
+            self.data["socket_"+str(socket)+"_apparantEnergySum"] =  round(self.decode_from_registers(energy_data.registers,44,4,self._client.DATATYPE.FLOAT64),2)      
                     
-            self.data["socket_"+str(socket)+"_reactiveEnergyL1"] =   round(self.decode_from_registers(energy_data.registers,108,4,self._client.DATATYPE.FLOAT64),2) 
-            self.data["socket_"+str(socket)+"_reactiveEnergyL2"] =   round(self.decode_from_registers(energy_data.registers,112,4,self._client.DATATYPE.FLOAT64),2) 
-            self.data["socket_"+str(socket)+"_reactiveEnergyL3"] =  round(self.decode_from_registers(energy_data.registers,116,4,self._client.DATATYPE.FLOAT64),2) 
-            self.data["socket_"+str(socket)+"_reactiveEnergySum"] = round(self.decode_from_registers(energy_data.registers,120,4,self._client.DATATYPE.FLOAT64),2)        
+            self.data["socket_"+str(socket)+"_reactiveEnergyL1"] =   round(self.decode_from_registers(energy_data.registers,48,4,self._client.DATATYPE.FLOAT64),2) 
+            self.data["socket_"+str(socket)+"_reactiveEnergyL2"] =   round(self.decode_from_registers(energy_data.registers,52,4,self._client.DATATYPE.FLOAT64),2) 
+            self.data["socket_"+str(socket)+"_reactiveEnergyL3"] =  round(self.decode_from_registers(energy_data.registers,56,4,self._client.DATATYPE.FLOAT64),2) 
+            self.data["socket_"+str(socket)+"_reactiveEnergySum"] = round(self.decode_from_registers(energy_data.registers,60,4,self._client.DATATYPE.FLOAT64),2)        
                                             
                             
             status_data = await self.read_holding_registers(socket,1200,16)

--- a/custom_components/alfen_modbus/__init__.py
+++ b/custom_components/alfen_modbus/__init__.py
@@ -380,7 +380,7 @@ class AlfenModbusHub:
             self.data["socket_"+str(socket)+"_powerL3"] =  round(self.decode_from_registers(energy_data.registers,32,2,self._client.DATATYPE.FLOAT32),2)
             self.data["socket_"+str(socket)+"_powerSum"] =   round(self.decode_from_registers(energy_data.registers,34,2,self._client.DATATYPE.FLOAT32),2)
             
-            self.data["socket_"+str(socket)+"_frequency"] =   round(self.decode_from_registers(energy_data.registers,36,2,self._client.DATATYPE.FLOAT32),2)
+            self.data["socket_"+str(socket)+"_frequency"] =   round(self.decode_from_registers(energy_data.registers,36,2,self._client.DATATYPE.FLOAT32),3)
             
             self.data["socket_"+str(socket)+"_realPowerL1"] =   round(self.decode_from_registers(energy_data.registers,38,2,self._client.DATATYPE.FLOAT32),2)
             self.data["socket_"+str(socket)+"_realPowerL2"] =   round(self.decode_from_registers(energy_data.registers,40,2,self._client.DATATYPE.FLOAT32),2)

--- a/custom_components/alfen_modbus/manifest.json
+++ b/custom_components/alfen_modbus/manifest.json
@@ -12,7 +12,7 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/ThaStealth/alfen_modbus/issues",
   "requirements": [
-    "pymodbus==3.11.2"
+    "pymodbus>=3.11.2"
   ],
   "version": "0.2.0"
 }

--- a/custom_components/alfen_modbus/number.py
+++ b/custom_components/alfen_modbus/number.py
@@ -62,7 +62,7 @@ async def async_setup_entry(hass, entry, async_add_entities) -> None:
     async_add_entities(entities)
     return True
 
-class AlfenNumber(NumberEntity):
+class AlfenNumber(AlfenEntity, NumberEntity):
     """Representation of an Alfen Modbus number."""
 
     def __init__(self,

--- a/simulator/test_real_alfen.py
+++ b/simulator/test_real_alfen.py
@@ -121,7 +121,7 @@ def read_product_info(client):
     log.info("")
     log.info("Station Status:")
     log.info(f"  Max Current:     {decode_float32(regs, 0):.1f} A")
-    log.info(f"  Temperature:     {decode_float32(regs, 2):.1f} °C")
+    log.info(f"  Temperature:     {decode_float32(regs, 2):.3f} °C")
     log.info(f"  Backoffice:      {'Connected' if decode_uint16(regs, 4) else 'Disconnected'}")
     log.info(f"  Sockets:         {decode_uint16(regs, 5)}")
 
@@ -133,8 +133,10 @@ def read_socket_info(client, socket_id):
     log.info(f"SOCKET {socket_id} MEASUREMENTS (Unit {socket_id})")
     log.info("=" * 60)
     
-    # Read meter registers 300-424 (125 registers)
-    result = client.read_holding_registers(address=300, count=125, device_id=socket_id)
+    # (previous) -> read meter registers 300-424 (125 registers)
+    # Fix: split read as 125 register's is too big for one read when reading from AHP platform.
+    # Read meter registers 300-362 (62 registers)
+    result = client.read_holding_registers(address=300, count=62, device_id=socket_id)
     if result.isError():
         log.error(f"Failed to read socket {socket_id} meters: {result}")
         return False
@@ -171,7 +173,7 @@ def read_socket_info(client, socket_id):
     log.info(f"  Sum:             {decode_float32(regs, 34):.3f}")
     
     log.info("")
-    log.info(f"Frequency:         {decode_float32(regs, 36):.2f} Hz")
+    log.info(f"Frequency:         {decode_float32(regs, 36):.3f} Hz")
     
     log.info("")
     log.info("Real Power (W):")
@@ -194,33 +196,40 @@ def read_socket_info(client, socket_id):
     log.info(f"  L3:              {decode_float32(regs, 58):.2f}")
     log.info(f"  Sum:             {decode_float32(regs, 60):.2f}")
     
+    # Read meter registers 362-426 (64 registers)
+    result = client.read_holding_registers(address=362, count=64, device_id=socket_id)
+    if result.isError():
+        log.error(f"Failed to read socket {socket_id} meters: {result}")
+        return False
+    
+    regs = result.registers
     log.info("")
     log.info("Real Energy Delivered (Wh):")
-    log.info(f"  L1:              {decode_float64(regs, 62):.2f}")
-    log.info(f"  L2:              {decode_float64(regs, 66):.2f}")
-    log.info(f"  L3:              {decode_float64(regs, 70):.2f}")
-    log.info(f"  Sum:             {decode_float64(regs, 74):.2f}")
+    log.info(f"  L1:              {decode_float64(regs, 0):.0f}")
+    log.info(f"  L2:              {decode_float64(regs, 4):.0f}")
+    log.info(f"  L3:              {decode_float64(regs, 8):.0f}")
+    log.info(f"  Sum:             {decode_float64(regs, 12):.0f}")
     
     log.info("")
     log.info("Real Energy Consumed (Wh):")
-    log.info(f"  L1:              {decode_float64(regs, 78):.2f}")
-    log.info(f"  L2:              {decode_float64(regs, 82):.2f}")
-    log.info(f"  L3:              {decode_float64(regs, 86):.2f}")
-    log.info(f"  Sum:             {decode_float64(regs, 90):.2f}")
+    log.info(f"  L1:              {decode_float64(regs, 16):.2f}")
+    log.info(f"  L2:              {decode_float64(regs, 20):.2f}")
+    log.info(f"  L3:              {decode_float64(regs, 24):.2f}")
+    log.info(f"  Sum:             {decode_float64(regs, 28):.2f}")
     
     log.info("")
     log.info("Apparent Energy (VAh):")
-    log.info(f"  L1:              {decode_float64(regs, 92):.2f}")
-    log.info(f"  L2:              {decode_float64(regs, 96):.2f}")
-    log.info(f"  L3:              {decode_float64(regs, 100):.2f}")
-    log.info(f"  Sum:             {decode_float64(regs, 104):.2f}")
+    log.info(f"  L1:              {decode_float64(regs, 32):.2f}")
+    log.info(f"  L2:              {decode_float64(regs, 36):.2f}")
+    log.info(f"  L3:              {decode_float64(regs, 40):.2f}")
+    log.info(f"  Sum:             {decode_float64(regs, 44):.2f}")
     
     log.info("")
     log.info("Reactive Energy (VArh):")
-    log.info(f"  L1:              {decode_float64(regs, 108):.2f}")
-    log.info(f"  L2:              {decode_float64(regs, 112):.2f}")
-    log.info(f"  L3:              {decode_float64(regs, 116):.2f}")
-    log.info(f"  Sum:             {decode_float64(regs, 120):.2f}")
+    log.info(f"  L1:              {decode_float64(regs, 48):.2f}")
+    log.info(f"  L2:              {decode_float64(regs, 52):.2f}")
+    log.info(f"  L3:              {decode_float64(regs, 56):.2f}")
+    log.info(f"  Sum:             {decode_float64(regs, 60):.2f}")
     
     # Read socket status 1200-1215
     result = client.read_holding_registers(address=1200, count=16, device_id=socket_id)


### PR DESCRIPTION
As a proud owner of a new AHP based Alfen Eve Single Plus I (and some others over in tweakers forum) experienced problems with the integration's reading of the modbus registers.

Hence I made some fixes to the integration in this PR.
What this PR includes:
- Splitting the socket modbus register reading into two register blocks "voltage, current, power" and "energy" as reading 125 registers in one go fails on AHP (applied in both test_real_alfen.py as __init__.py) 
- Adjusting the decimals of board temperature and frequency (as they contain 3 decimals).
- Updating the manifest to prevent HA failing at the pymodbus version requirement.
- Updating the README to include AHPxx.

Best,
Tristan