### PR TITLE
Fix socket measurement read for AHP platform (fixes #40)

### DIFF
--- a/custom_components/alfen_modbus/__init__.py
+++ b/custom_components/alfen_modbus/__init__.py
@@ -71,7 +71,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     read_scn = entry.data.get(CONF_READ_SCN, False)
     read_socket2 = entry.data.get(CONF_READ_SOCKET2, False)
 
-    _LOGGER.debug("Setup %s.%s", DOMAIN, name)
+    _LOGGER.info("Setup %s.%s (integration v0.2.1, split socket reads, fixes issue #40)", DOMAIN, name)
 
     hub = AlfenModbusHub(
         hass,
@@ -270,6 +270,22 @@ class AlfenModbusHub:
                 _LOGGER.error("Failed to reconnect and retry read: %s", retry_error)
                 raise
 
+    async def read_holding_registers_split(self, unit, chunks):
+        """Read holding registers in multiple chunks and concatenate them.
+
+        Needed because the socket measurement block (300-425) is 126 registers,
+        which exceeds the 125-register FC3 limit. Chunks must align with value
+        boundaries: firmware rejects reads that partially cover a defined value.
+        Returns the concatenated register list, or None if any chunk fails.
+        """
+        registers = []
+        for address, count in chunks:
+            result = await self.read_holding_registers(unit, address, count)
+            if result is None or result.isError():
+                return None
+            registers.extend(result.registers)
+        return registers
+
     async def write_registers(self, unit, address, payload):
         """Write registers."""
         try:
@@ -352,67 +368,72 @@ class AlfenModbusHub:
         
     async def read_modbus_data_socket(self,socket):
         if((socket == 1) or (socket == 2 and self.has_socket_2 and self.data["numberOfSockets"] >= 2)):
-            energy_data = await self.read_holding_registers(socket,300,125)
-            if energy_data.isError():
+            # Block is 300-425 (126 registers): exceeds the FC3 125-register
+            # limit, so read as two value-aligned chunks. Split at 362 lands
+            # after Reactive Power Sum (360-361) and before the first FLOAT64.
+            energy_registers = await self.read_holding_registers_split(
+                socket, [(300, 62), (362, 64)]
+            )
+            if energy_registers is None:
                 return False
 
 
      
-            self.data["socket_"+str(socket)+"_meterstate"] =  self.decode_from_registers(energy_data.registers,0,1,self._client.DATATYPE.UINT16)
-            self.data["socket_"+str(socket)+"_meterAge"] =  self.decode_from_registers(energy_data.registers,1,4,self._client.DATATYPE.UINT16)
-            self.data["socket_"+str(socket)+"_meterType"] =  self.decode_from_registers(energy_data.registers,5,1,self._client.DATATYPE.UINT16)
+            self.data["socket_"+str(socket)+"_meterstate"] =  self.decode_from_registers(energy_registers,0,1,self._client.DATATYPE.UINT16)
+            self.data["socket_"+str(socket)+"_meterAge"] =  self.decode_from_registers(energy_registers,1,4,self._client.DATATYPE.UINT16)
+            self.data["socket_"+str(socket)+"_meterType"] =  self.decode_from_registers(energy_registers,5,1,self._client.DATATYPE.UINT16)
             
-            self.data["socket_"+str(socket)+"_VL1-N"] =   round(self.decode_from_registers(energy_data.registers,6,2,self._client.DATATYPE.FLOAT32),2)
-            self.data["socket_"+str(socket)+"_VL2-N"] =   round(self.decode_from_registers(energy_data.registers,8,2,self._client.DATATYPE.FLOAT32),2)
-            self.data["socket_"+str(socket)+"_VL3-N"] =   round(self.decode_from_registers(energy_data.registers,10,2,self._client.DATATYPE.FLOAT32),2)
+            self.data["socket_"+str(socket)+"_VL1-N"] =   round(self.decode_from_registers(energy_registers,6,2,self._client.DATATYPE.FLOAT32),2)
+            self.data["socket_"+str(socket)+"_VL2-N"] =   round(self.decode_from_registers(energy_registers,8,2,self._client.DATATYPE.FLOAT32),2)
+            self.data["socket_"+str(socket)+"_VL3-N"] =   round(self.decode_from_registers(energy_registers,10,2,self._client.DATATYPE.FLOAT32),2)
             
-            self.data["socket_"+str(socket)+"_VL1-L2"] =  round(self.decode_from_registers(energy_data.registers,12,2,self._client.DATATYPE.FLOAT32),2)
-            self.data["socket_"+str(socket)+"_VL2-L3"] =   round(self.decode_from_registers(energy_data.registers,14,2,self._client.DATATYPE.FLOAT32),2)
-            self.data["socket_"+str(socket)+"_VL3-L1"] =   round(self.decode_from_registers(energy_data.registers,16,2,self._client.DATATYPE.FLOAT32),2)
+            self.data["socket_"+str(socket)+"_VL1-L2"] =  round(self.decode_from_registers(energy_registers,12,2,self._client.DATATYPE.FLOAT32),2)
+            self.data["socket_"+str(socket)+"_VL2-L3"] =   round(self.decode_from_registers(energy_registers,14,2,self._client.DATATYPE.FLOAT32),2)
+            self.data["socket_"+str(socket)+"_VL3-L1"] =   round(self.decode_from_registers(energy_registers,16,2,self._client.DATATYPE.FLOAT32),2)
             
-            self.data["socket_"+str(socket)+"_currentN"] =   round(self.decode_from_registers(energy_data.registers,18,2,self._client.DATATYPE.FLOAT32),2)
-            self.data["socket_"+str(socket)+"_currentL1"] =   round(self.decode_from_registers(energy_data.registers,20,2,self._client.DATATYPE.FLOAT32),2)
-            self.data["socket_"+str(socket)+"_currentL2"] =   round(self.decode_from_registers(energy_data.registers,22,2,self._client.DATATYPE.FLOAT32),2)
-            self.data["socket_"+str(socket)+"_currentL3"] =  round(self.decode_from_registers(energy_data.registers,24,2,self._client.DATATYPE.FLOAT32),2)
-            self.data["socket_"+str(socket)+"_currentSum"] =   round(self.decode_from_registers(energy_data.registers,26,2,self._client.DATATYPE.FLOAT32),2)
-            self.data["socket_"+str(socket)+"_powerL1"] =  round(self.decode_from_registers(energy_data.registers,28,2,self._client.DATATYPE.FLOAT32),2)
-            self.data["socket_"+str(socket)+"_powerL2"] =   round(self.decode_from_registers(energy_data.registers,30,2,self._client.DATATYPE.FLOAT32),2)
-            self.data["socket_"+str(socket)+"_powerL3"] =  round(self.decode_from_registers(energy_data.registers,32,2,self._client.DATATYPE.FLOAT32),2)
-            self.data["socket_"+str(socket)+"_powerSum"] =   round(self.decode_from_registers(energy_data.registers,34,2,self._client.DATATYPE.FLOAT32),2)
+            self.data["socket_"+str(socket)+"_currentN"] =   round(self.decode_from_registers(energy_registers,18,2,self._client.DATATYPE.FLOAT32),2)
+            self.data["socket_"+str(socket)+"_currentL1"] =   round(self.decode_from_registers(energy_registers,20,2,self._client.DATATYPE.FLOAT32),2)
+            self.data["socket_"+str(socket)+"_currentL2"] =   round(self.decode_from_registers(energy_registers,22,2,self._client.DATATYPE.FLOAT32),2)
+            self.data["socket_"+str(socket)+"_currentL3"] =  round(self.decode_from_registers(energy_registers,24,2,self._client.DATATYPE.FLOAT32),2)
+            self.data["socket_"+str(socket)+"_currentSum"] =   round(self.decode_from_registers(energy_registers,26,2,self._client.DATATYPE.FLOAT32),2)
+            self.data["socket_"+str(socket)+"_powerL1"] =  round(self.decode_from_registers(energy_registers,28,2,self._client.DATATYPE.FLOAT32),2)
+            self.data["socket_"+str(socket)+"_powerL2"] =   round(self.decode_from_registers(energy_registers,30,2,self._client.DATATYPE.FLOAT32),2)
+            self.data["socket_"+str(socket)+"_powerL3"] =  round(self.decode_from_registers(energy_registers,32,2,self._client.DATATYPE.FLOAT32),2)
+            self.data["socket_"+str(socket)+"_powerSum"] =   round(self.decode_from_registers(energy_registers,34,2,self._client.DATATYPE.FLOAT32),2)
             
-            self.data["socket_"+str(socket)+"_frequency"] =   round(self.decode_from_registers(energy_data.registers,36,2,self._client.DATATYPE.FLOAT32),2)
+            self.data["socket_"+str(socket)+"_frequency"] =   round(self.decode_from_registers(energy_registers,36,2,self._client.DATATYPE.FLOAT32),2)
             
-            self.data["socket_"+str(socket)+"_realPowerL1"] =   round(self.decode_from_registers(energy_data.registers,38,2,self._client.DATATYPE.FLOAT32),2)
-            self.data["socket_"+str(socket)+"_realPowerL2"] =   round(self.decode_from_registers(energy_data.registers,40,2,self._client.DATATYPE.FLOAT32),2)
-            self.data["socket_"+str(socket)+"_realPowerL3"] =   round(self.decode_from_registers(energy_data.registers,42,2,self._client.DATATYPE.FLOAT32),2)
-            self.data["socket_"+str(socket)+"_realPowerSum"] =   round(self.decode_from_registers(energy_data.registers,44,2,self._client.DATATYPE.FLOAT32),2)    
-            self.data["socket_"+str(socket)+"_apparantPowerL1"] =   round(self.decode_from_registers(energy_data.registers,46,2,self._client.DATATYPE.FLOAT32),2)
-            self.data["socket_"+str(socket)+"_apparantPowerL2"] =   round(self.decode_from_registers(energy_data.registers,48,2,self._client.DATATYPE.FLOAT32),2)
-            self.data["socket_"+str(socket)+"_apparantPowerL3"] =  round(self.decode_from_registers(energy_data.registers,50,2,self._client.DATATYPE.FLOAT32),2)
-            self.data["socket_"+str(socket)+"_apparantPowerSum"] =  round(self.decode_from_registers(energy_data.registers,52,2,self._client.DATATYPE.FLOAT32),2)
+            self.data["socket_"+str(socket)+"_realPowerL1"] =   round(self.decode_from_registers(energy_registers,38,2,self._client.DATATYPE.FLOAT32),2)
+            self.data["socket_"+str(socket)+"_realPowerL2"] =   round(self.decode_from_registers(energy_registers,40,2,self._client.DATATYPE.FLOAT32),2)
+            self.data["socket_"+str(socket)+"_realPowerL3"] =   round(self.decode_from_registers(energy_registers,42,2,self._client.DATATYPE.FLOAT32),2)
+            self.data["socket_"+str(socket)+"_realPowerSum"] =   round(self.decode_from_registers(energy_registers,44,2,self._client.DATATYPE.FLOAT32),2)    
+            self.data["socket_"+str(socket)+"_apparantPowerL1"] =   round(self.decode_from_registers(energy_registers,46,2,self._client.DATATYPE.FLOAT32),2)
+            self.data["socket_"+str(socket)+"_apparantPowerL2"] =   round(self.decode_from_registers(energy_registers,48,2,self._client.DATATYPE.FLOAT32),2)
+            self.data["socket_"+str(socket)+"_apparantPowerL3"] =  round(self.decode_from_registers(energy_registers,50,2,self._client.DATATYPE.FLOAT32),2)
+            self.data["socket_"+str(socket)+"_apparantPowerSum"] =  round(self.decode_from_registers(energy_registers,52,2,self._client.DATATYPE.FLOAT32),2)
                     
-            self.data["socket_"+str(socket)+"_reactivePowerL1"] =   round(self.decode_from_registers(energy_data.registers,54,2,self._client.DATATYPE.FLOAT32),2)
-            self.data["socket_"+str(socket)+"_reactivePowerL2"] =   round(self.decode_from_registers(energy_data.registers,56,2,self._client.DATATYPE.FLOAT32),2)
-            self.data["socket_"+str(socket)+"_reactivePowerL3"] =   round(self.decode_from_registers(energy_data.registers,58,2,self._client.DATATYPE.FLOAT32),2)
-            self.data["socket_"+str(socket)+"_reactivePowerSum"] =   round(self.decode_from_registers(energy_data.registers,60,2,self._client.DATATYPE.FLOAT32),2)
+            self.data["socket_"+str(socket)+"_reactivePowerL1"] =   round(self.decode_from_registers(energy_registers,54,2,self._client.DATATYPE.FLOAT32),2)
+            self.data["socket_"+str(socket)+"_reactivePowerL2"] =   round(self.decode_from_registers(energy_registers,56,2,self._client.DATATYPE.FLOAT32),2)
+            self.data["socket_"+str(socket)+"_reactivePowerL3"] =   round(self.decode_from_registers(energy_registers,58,2,self._client.DATATYPE.FLOAT32),2)
+            self.data["socket_"+str(socket)+"_reactivePowerSum"] =   round(self.decode_from_registers(energy_registers,60,2,self._client.DATATYPE.FLOAT32),2)
 
-            self.data["socket_"+str(socket)+"_realEnergyDeliveredL1"] = round(self.decode_from_registers(energy_data.registers,62,4,self._client.DATATYPE.FLOAT64),2) 
-            self.data["socket_"+str(socket)+"_realEnergyDeliveredL2"] =   round(self.decode_from_registers(energy_data.registers,66,4,self._client.DATATYPE.FLOAT64),2) 
-            self.data["socket_"+str(socket)+"_realEnergyDeliveredL3"] =   round(self.decode_from_registers(energy_data.registers,70,4,self._client.DATATYPE.FLOAT64),2) 
-            self.data["socket_"+str(socket)+"_realEnergyDeliveredSum"] =   round(self.decode_from_registers(energy_data.registers,74,4,self._client.DATATYPE.FLOAT64),2) 
-            self.data["socket_"+str(socket)+"_realEnergyConsumedL1"] =  round(self.decode_from_registers(energy_data.registers,78,4,self._client.DATATYPE.FLOAT64),2) 
-            self.data["socket_"+str(socket)+"_realEnergyConsumedL2"] =   round(self.decode_from_registers(energy_data.registers,82,4,self._client.DATATYPE.FLOAT64),2) 
-            self.data["socket_"+str(socket)+"_realEnergyConsumedL3"] =  round(self.decode_from_registers(energy_data.registers,86,4,self._client.DATATYPE.FLOAT64),2) 
-            self.data["socket_"+str(socket)+"_realEnergyConsumedSum"] =   round(self.decode_from_registers(energy_data.registers,90,4,self._client.DATATYPE.FLOAT64),2)     
-            self.data["socket_"+str(socket)+"_apparantEnergyL1"] =  round(self.decode_from_registers(energy_data.registers,92,4,self._client.DATATYPE.FLOAT64),2) 
-            self.data["socket_"+str(socket)+"_apparantEnergyL2"] =   round(self.decode_from_registers(energy_data.registers,96,4,self._client.DATATYPE.FLOAT64),2) 
-            self.data["socket_"+str(socket)+"_apparantEnergyL3"] =  round(self.decode_from_registers(energy_data.registers,100,4,self._client.DATATYPE.FLOAT64),2) 
-            self.data["socket_"+str(socket)+"_apparantEnergySum"] =  round(self.decode_from_registers(energy_data.registers,104,4,self._client.DATATYPE.FLOAT64),2)      
+            self.data["socket_"+str(socket)+"_realEnergyDeliveredL1"] = round(self.decode_from_registers(energy_registers,62,4,self._client.DATATYPE.FLOAT64),2) 
+            self.data["socket_"+str(socket)+"_realEnergyDeliveredL2"] =   round(self.decode_from_registers(energy_registers,66,4,self._client.DATATYPE.FLOAT64),2) 
+            self.data["socket_"+str(socket)+"_realEnergyDeliveredL3"] =   round(self.decode_from_registers(energy_registers,70,4,self._client.DATATYPE.FLOAT64),2) 
+            self.data["socket_"+str(socket)+"_realEnergyDeliveredSum"] =   round(self.decode_from_registers(energy_registers,74,4,self._client.DATATYPE.FLOAT64),2) 
+            self.data["socket_"+str(socket)+"_realEnergyConsumedL1"] =  round(self.decode_from_registers(energy_registers,78,4,self._client.DATATYPE.FLOAT64),2) 
+            self.data["socket_"+str(socket)+"_realEnergyConsumedL2"] =   round(self.decode_from_registers(energy_registers,82,4,self._client.DATATYPE.FLOAT64),2) 
+            self.data["socket_"+str(socket)+"_realEnergyConsumedL3"] =  round(self.decode_from_registers(energy_registers,86,4,self._client.DATATYPE.FLOAT64),2) 
+            self.data["socket_"+str(socket)+"_realEnergyConsumedSum"] =   round(self.decode_from_registers(energy_registers,90,4,self._client.DATATYPE.FLOAT64),2)     
+            self.data["socket_"+str(socket)+"_apparantEnergyL1"] =  round(self.decode_from_registers(energy_registers,94,4,self._client.DATATYPE.FLOAT64),2) 
+            self.data["socket_"+str(socket)+"_apparantEnergyL2"] =  round(self.decode_from_registers(energy_registers,98,4,self._client.DATATYPE.FLOAT64),2) 
+            self.data["socket_"+str(socket)+"_apparantEnergyL3"] =  round(self.decode_from_registers(energy_registers,102,4,self._client.DATATYPE.FLOAT64),2) 
+            self.data["socket_"+str(socket)+"_apparantEnergySum"] =  round(self.decode_from_registers(energy_registers,106,4,self._client.DATATYPE.FLOAT64),2)      
                     
-            self.data["socket_"+str(socket)+"_reactiveEnergyL1"] =   round(self.decode_from_registers(energy_data.registers,108,4,self._client.DATATYPE.FLOAT64),2) 
-            self.data["socket_"+str(socket)+"_reactiveEnergyL2"] =   round(self.decode_from_registers(energy_data.registers,112,4,self._client.DATATYPE.FLOAT64),2) 
-            self.data["socket_"+str(socket)+"_reactiveEnergyL3"] =  round(self.decode_from_registers(energy_data.registers,116,4,self._client.DATATYPE.FLOAT64),2) 
-            self.data["socket_"+str(socket)+"_reactiveEnergySum"] = round(self.decode_from_registers(energy_data.registers,120,4,self._client.DATATYPE.FLOAT64),2)        
+            self.data["socket_"+str(socket)+"_reactiveEnergyL1"] =  round(self.decode_from_registers(energy_registers,110,4,self._client.DATATYPE.FLOAT64),2) 
+            self.data["socket_"+str(socket)+"_reactiveEnergyL2"] =  round(self.decode_from_registers(energy_registers,114,4,self._client.DATATYPE.FLOAT64),2) 
+            self.data["socket_"+str(socket)+"_reactiveEnergyL3"] =  round(self.decode_from_registers(energy_registers,118,4,self._client.DATATYPE.FLOAT64),2) 
+            self.data["socket_"+str(socket)+"_reactiveEnergySum"] = round(self.decode_from_registers(energy_registers,122,4,self._client.DATATYPE.FLOAT64),2)        
                                             
                             
             status_data = await self.read_holding_registers(socket,1200,16)

--- a/custom_components/alfen_modbus/manifest.json
+++ b/custom_components/alfen_modbus/manifest.json
@@ -14,5 +14,5 @@
   "requirements": [
     "pymodbus==3.11.2"
   ],
-  "version": "0.2.0"
+  "version": "0.2.1"
 }

--- a/simulator/simulator.py
+++ b/simulator/simulator.py
@@ -24,6 +24,7 @@ import sys
 import os
 from pymodbus.server import StartAsyncTcpServer
 from pymodbus.datastore import ModbusSequentialDataBlock, ModbusServerContext, ModbusDeviceContext
+from pymodbus.constants import ExcCodes
 from pymodbus.pdu.device import ModbusDeviceIdentification
 
 # Default Configuration - matches real Alfen hardware
@@ -142,6 +143,54 @@ def reg(register):
     return register + 1
 
 # ============================================================================
+# Strict data block (mimics AHP firmware behaviour)
+# ============================================================================
+
+# Value layout of the socket map in client register addresses: (start, length).
+# The 16 float64 energy counters pack 362-425 exactly, ending at 425 inclusive.
+SOCKET_VALUE_LAYOUT = (
+    [(300, 1), (301, 4), (305, 1)]                       # meter state/age/type
+    + [(306 + 2 * i, 2) for i in range(28)]              # float32s, 306-361
+    + [(362 + 4 * i, 4) for i in range(16)]              # float64s, 362-425
+    + [(1200, 1), (1201, 5), (1206, 2), (1208, 2),       # status/control block
+       (1210, 2), (1212, 2), (1214, 1), (1215, 1)]
+)
+
+class StrictValueDataBlock(ModbusSequentialDataBlock):
+    """Data block that rejects reads partially covering a defined value.
+
+    Mirrors strict firmwares (e.g. Alfen AHP): a request is only served when
+    it fully covers every value it touches and contains no unmapped register.
+    Any other request yields Modbus exception 02 (Illegal Data Address).
+    pymodbus 3.11 blocks have no validate(); getValues() receives block
+    addresses (client register + 1, see reg()) and signals range errors by
+    returning ExcCodes.ILLEGAL_ADDRESS, so strictness is enforced there.
+    """
+
+    def __init__(self, value_layout, address=0, size=2000):
+        super().__init__(address, [0] * size)
+        self._address_map = {}
+        self._value_ranges = []
+        for start, length in value_layout:
+            value_id = len(self._value_ranges)
+            block_start = reg(start)
+            self._value_ranges.append((block_start, block_start + length))
+            for block_addr in range(block_start, block_start + length):
+                self._address_map[block_addr] = value_id
+
+    def getValues(self, address, count=1):
+        touched = set()
+        for block_addr in range(address, address + count):
+            value_id = self._address_map.get(block_addr)
+            if value_id is None:
+                return ExcCodes.ILLEGAL_ADDRESS
+            touched.add(value_id)
+        for start, end in (self._value_ranges[i] for i in touched):
+            if start < address or end > address + count:
+                return ExcCodes.ILLEGAL_ADDRESS
+        return super().getValues(address, count)
+
+# ============================================================================
 # Product/Station Context (Unit 200)
 # ============================================================================
 
@@ -182,11 +231,16 @@ def setup_product_context():
 # ============================================================================
 
 def setup_socket_context(socket_id):
-    """Sets up a socket context (Unit 1 or 2)."""
-    block = ModbusSequentialDataBlock(0, [0]*2000)
+    """Sets up a socket context (Unit 1 or 2).
+
+    Uses StrictValueDataBlock so the simulator rejects reads that partially
+    cover a defined value, like the AHP firmware does.
+    """
+    block = StrictValueDataBlock(SOCKET_VALUE_LAYOUT)
     
-    # === Meter Measurements (Registers 300-424) ===
-    # HA reads registers 300-424 (125 registers) and uses offsets from 300
+    # === Meter Measurements (Registers 300-425, 126 registers) ===
+    # HA reads this as two value-aligned chunks (300-361 and 362-425)
+    # and uses offsets from 300 against the concatenated block.
     block.setValues(reg(300), encode_uint16(3))      # Meter State (offset 0)
     block.setValues(reg(301), encode_uint32(1500))   # Meter Age ms (offset 1, 4 regs but read as UINT16)
     block.setValues(reg(305), encode_uint16(1))      # Meter Type (offset 5)
@@ -247,21 +301,20 @@ def setup_socket_context(socket_id):
     block.setValues(reg(386), encode_double(0.0))
     block.setValues(reg(390), encode_double(0.0))
     
-    # Apparent Energy (float64, VAh) - offset 92, 96, 100, 104
-    block.setValues(reg(392), encode_double(15542.0))
-    block.setValues(reg(396), encode_double(15485.0))
-    block.setValues(reg(400), encode_double(15612.0))
-    block.setValues(reg(404), encode_double(46639.0))
+    # Apparent Energy (float64, VAh) - offset 94, 98, 102, 106
+    block.setValues(reg(394), encode_double(15542.0))
+    block.setValues(reg(398), encode_double(15485.0))
+    block.setValues(reg(402), encode_double(15612.0))
+    block.setValues(reg(406), encode_double(46639.0))
     
-    # Reactive Energy (float64, VArh) - offset 108, 112, 116, 120
-    block.setValues(reg(408), encode_double(3024.0))
-    block.setValues(reg(412), encode_double(3189.0))
-    block.setValues(reg(416), encode_double(2956.0))
-    block.setValues(reg(420), encode_double(9169.0))  # Reactive Energy Sum
+    # Reactive Energy (float64, VArh) - offset 110, 114, 118, 122
+    block.setValues(reg(410), encode_double(3024.0))
+    block.setValues(reg(414), encode_double(3189.0))
+    block.setValues(reg(418), encode_double(2956.0))
+    block.setValues(reg(422), encode_double(9169.0))  # Reactive Energy Sum (422-425)
     
     # === Socket Status/Control (Registers 1200-1215) ===
-    # HA reads registers 1200-1215 (16 registers)
-    block.setValues(reg(1200), encode_uint16(1))     # Availability (offset 0)
+    # HA reads registers 1200-1215 (16 registers)    block.setValues(reg(1200), encode_uint16(1))     # Availability (offset 0)
     block.setValues(reg(1201), encode_string("C2", 10))  # Mode 3 State (offset 1, 5 regs)
     block.setValues(reg(1206), encode_float(16.0))   # Actual Applied Max Current (offset 6)
     block.setValues(reg(1208), encode_uint32(60))    # Max Current Valid Time (offset 8)

--- a/simulator/smoke_test_ha.py
+++ b/simulator/smoke_test_ha.py
@@ -185,20 +185,25 @@ async def test_station_data(client, unit, result):
 
 async def test_socket_energy_data(client, socket_id, result):
     """
-    Tests read_modbus_data_socket() - Registers 300-424 (125 registers)
+    Tests read_modbus_data_socket() - Registers 300-425 (126 registers, read
+    as two value-aligned chunks)
     
     This is called from: read_modbus_data_socket() in __init__.py
     Socket 1 uses unit=1, Socket 2 uses unit=2
     """
-    log.info("\n=== Test: Socket %d Energy Data (Unit %d, Registers 300-424) ===" % (socket_id, socket_id))
-    
-    rr = await client.read_holding_registers(300, count=125, device_id=socket_id)
-    if rr.isError():
-        log.error(f"Failed to read socket {socket_id} energy data: {rr}")
-        result.failed += 1
-        return
-    
-    regs = rr.registers
+    log.info("\n=== Test: Socket %d Energy Data (Unit %d, Registers 300-425) ===" % (socket_id, socket_id))
+
+    # Read as two value-aligned chunks (300-361, 362-425); the 126-register
+    # block exceeds the FC3 125-register limit and firmware rejects reads
+    # that partially cover a defined value.
+    regs = []
+    for address, count in ((300, 62), (362, 64)):
+        rr = await client.read_holding_registers(address, count=count, device_id=socket_id)
+        if rr.isError():
+            log.error(f"Failed to read socket {socket_id} energy data at {address}: {rr}")
+            result.failed += 1
+            return
+        regs.extend(rr.registers)
     
     # Decode exactly as HA component does (offsets from register 300)
     meter_state = decode_uint16(regs, 0)

--- a/simulator/test_real_alfen.py
+++ b/simulator/test_real_alfen.py
@@ -133,13 +133,16 @@ def read_socket_info(client, socket_id):
     log.info(f"SOCKET {socket_id} MEASUREMENTS (Unit {socket_id})")
     log.info("=" * 60)
     
-    # Read meter registers 300-424 (125 registers)
-    result = client.read_holding_registers(address=300, count=125, device_id=socket_id)
-    if result.isError():
-        log.error(f"Failed to read socket {socket_id} meters: {result}")
-        return False
-    
-    regs = result.registers
+    # Read meter registers 300-425 (126 registers) as two value-aligned chunks,
+    # since a single FC3 read is capped at 125 registers and firmware rejects
+    # reads that partially cover a defined value.
+    regs = []
+    for address, count in ((300, 62), (362, 64)):
+        result = client.read_holding_registers(address=address, count=count, device_id=socket_id)
+        if result.isError():
+            log.error(f"Failed to read socket {socket_id} meters at {address}: {result}")
+            return False
+        regs.extend(result.registers)
     
     log.info("Meter Info:")
     log.info(f"  State:           {decode_uint16(regs, 0)}")
@@ -210,17 +213,17 @@ def read_socket_info(client, socket_id):
     
     log.info("")
     log.info("Apparent Energy (VAh):")
-    log.info(f"  L1:              {decode_float64(regs, 92):.2f}")
-    log.info(f"  L2:              {decode_float64(regs, 96):.2f}")
-    log.info(f"  L3:              {decode_float64(regs, 100):.2f}")
-    log.info(f"  Sum:             {decode_float64(regs, 104):.2f}")
+    log.info(f"  L1:              {decode_float64(regs, 94):.2f}")
+    log.info(f"  L2:              {decode_float64(regs, 98):.2f}")
+    log.info(f"  L3:              {decode_float64(regs, 102):.2f}")
+    log.info(f"  Sum:             {decode_float64(regs, 106):.2f}")
     
     log.info("")
     log.info("Reactive Energy (VArh):")
-    log.info(f"  L1:              {decode_float64(regs, 108):.2f}")
-    log.info(f"  L2:              {decode_float64(regs, 112):.2f}")
-    log.info(f"  L3:              {decode_float64(regs, 116):.2f}")
-    log.info(f"  Sum:             {decode_float64(regs, 120):.2f}")
+    log.info(f"  L1:              {decode_float64(regs, 110):.2f}")
+    log.info(f"  L2:              {decode_float64(regs, 114):.2f}")
+    log.info(f"  L3:              {decode_float64(regs, 118):.2f}")
+    log.info(f"  Sum:             {decode_float64(regs, 122):.2f}")
     
     # Read socket status 1200-1215
     result = client.read_holding_registers(address=1200, count=16, device_id=socket_id)


### PR DESCRIPTION
Fixes #40.

## Problem

The socket measurement block is registers 300-425 inclusive = 126 registers, which exceeds the FC3 limit of 125. The single `read_holding_registers(300, 125)` covered 300-424 and cut the final FLOAT64 (Reactive Energy Sum, 422-425) in half. Strict firmwares (verified on AHP02-60227, firmware 2.6.0) reject reads that partially cover a defined value with exception 02 (Illegal Data Address), so every poll cycle failed and all entities stayed unavailable.

126 registers can never fit in one FC3 request on any platform, so the fix applies unconditionally, not just to AHP.

## Changes

- Read the block as two value-aligned chunks: `(300, 62)` (ends after Reactive Power Sum) and `(362, 64)` (the 16 packed FLOAT64 energy counters) via a new `read_holding_registers_split()` helper. Both chunks verified against real AHP hardware.
- Fix apparent/reactive energy decode offsets (+2): the 16 FLOAT64 values pack registers 362-425 exactly, so the previous offsets overlapped `realEnergyConsumedSum` and misdecoded apparent/reactive energy — on every platform, not just AHP.
- Simulator: register energy values at the corrected addresses and add `StrictValueDataBlock`, which rejects partial-value reads the way AHP firmware does, so this class of regression is caught in local testing going forward.
- Update `simulator/test_real_alfen.py` and `simulator/smoke_test_ha.py` to the split reads and corrected offsets.
- Bump integration version to 0.2.1.

## Testing

- Verified against real AHP02-60227 hardware: both chunks succeed where the old single read failed with exception 02.
- Verified against the patched simulator: `test_simulator.py` and `smoke_test_ha.py` (31 checks including the 1210->1206 write/mirror) pass.
- Decoded values cross-checked against the simulator's known inputs after the offset fix (e.g. apparent/reactive energy sums).