### PR TITLE
Fix number platform setup failure (fixes #41)

### DIFF
--- a/custom_components/alfen_modbus/number.py
+++ b/custom_components/alfen_modbus/number.py
@@ -62,7 +62,7 @@ async def async_setup_entry(hass, entry, async_add_entities) -> None:
     async_add_entities(entities)
     return True
 
-class AlfenNumber(NumberEntity):
+class AlfenNumber(AlfenEntity, NumberEntity):
     """Representation of an Alfen Modbus number."""
 
     def __init__(self,


### PR DESCRIPTION
Fixes #41.

`AlfenNumber` only inherited from `NumberEntity` but called `super().__init__(hub, device_info)`, which is `AlfenEntity`'s signature. Since `AlfenNumber` didn't inherit from `AlfenEntity`, the call hit `object.__init__()` and raised, so the number platform (Max Current slider) never loaded.

Fix: inherit from `(AlfenEntity, NumberEntity)`, matching `AlfenSensor`.

## Testing

Verified locally: the number platform now sets up without error, `self._hub` is available, and the Max Current slider entity appears and successfully writes to register 1210.