### PR TITLE
Fix car connected/charging detection for Mode 3 state variants (fixes #42)

### DIFF
--- a/custom_components/alfen_modbus/__init__.py
+++ b/custom_components/alfen_modbus/__init__.py
@@ -420,21 +420,24 @@ class AlfenModbusHub:
                 return False
   
             self.data["socket_"+str(socket)+"_available"] =  self.decode_from_registers(status_data.registers, 0, 1,self._client.DATATYPE.UINT16) 
-            self.data["socket_"+str(socket)+"_mode3state"] =  self.decode_from_registers(status_data.registers, 1, 5, self._client.DATATYPE.STRING).strip('\x00')       
-            self.data["socket_"+str(socket)+"_actualMaxCurrent"] =   round(self.decode_from_registers(status_data.registers,6,2,self._client.DATATYPE.FLOAT32),2)   
-            self.data[VALID_TIME_S+str(socket)] = self.decode_from_registers(status_data.registers, 8, 2,self._client.DATATYPE.UINT32) 
-            self.data[MAX_CURRENT_S+str(socket)] =  round(self.decode_from_registers(status_data.registers,10,2,self._client.DATATYPE.FLOAT32),2)      
-            self.data["socket_"+str(socket)+"_saveCurrent"] =  round(self.decode_from_registers(status_data.registers,12,2,self._client.DATATYPE.FLOAT32),2)       
-            self.data["socket_"+str(socket)+"_setpointAccounted"] =  self.decode_from_registers(status_data.registers, 14, 1,self._client.DATATYPE.UINT16)    
-            self.data["socket_"+str(socket)+"_chargephases"] =  self.decode_from_registers(status_data.registers, 15, 1,self._client.DATATYPE.UINT16) 
-            
-            if self.data["socket_"+str(socket)+"_mode3state"] in ["A","E","F"]:
-                self.data["socket_"+str(socket)+"_carconnected"] = 0             
+            mode3 = self.decode_from_registers(status_data.registers, 1, 5, self._client.DATATYPE.STRING).strip('\x00').strip().upper()
+            self.data["socket_"+str(socket)+"_mode3state"] = mode3
+            self.data["socket_"+str(socket)+"_actualMaxCurrent"] =   round(self.decode_from_registers(status_data.registers,6,2,self._client.DATATYPE.FLOAT32),2)
+            self.data[VALID_TIME_S+str(socket)] = self.decode_from_registers(status_data.registers, 8, 2,self._client.DATATYPE.UINT32)
+            self.data[MAX_CURRENT_S+str(socket)] =  round(self.decode_from_registers(status_data.registers,10,2,self._client.DATATYPE.FLOAT32),2)
+            self.data["socket_"+str(socket)+"_saveCurrent"] =  round(self.decode_from_registers(status_data.registers,12,2,self._client.DATATYPE.FLOAT32),2)
+            self.data["socket_"+str(socket)+"_setpointAccounted"] =  self.decode_from_registers(status_data.registers, 14, 1,self._client.DATATYPE.UINT16)
+            self.data["socket_"+str(socket)+"_chargephases"] =  self.decode_from_registers(status_data.registers, 15, 1,self._client.DATATYPE.UINT16)
+
+            # IEC 61851 state families: A/E/F idle, B connected, C/D charging.
+            # Prefix matching (A1, C2, FF, ...) - exact match misclassifies variants.
+            if not mode3 or mode3.startswith(("A", "E", "F")):
+                self.data["socket_"+str(socket)+"_carconnected"] = 0
             else:
-                self.data["socket_"+str(socket)+"_carconnected"] = 1          
-            
-            if self.data["socket_"+str(socket)+"_mode3state"] not in ["C2","D2"]:
-                self.data["socket_"+str(socket)+"_carcharging"] = 0                    
+                self.data["socket_"+str(socket)+"_carconnected"] = 1
+
+            if not mode3.startswith(("C", "D")):
+                self.data["socket_"+str(socket)+"_carcharging"] = 0
             else:
                 if "socket_"+str(socket)+"_carcharging" not in self.data or self.data["socket_"+str(socket)+"_carcharging"] == 0:                    
                     self.data["socket_"+str(socket)+"_chargingStartWh"] = self.data["socket_"+str(socket)+"_realEnergyDeliveredSum"]


### PR DESCRIPTION
Fixes #42.

Exact-match checks against `A`/`E`/`F` and `C2`/`D2` misclassify any state variant the charger actually reports (e.g. `A1`, `B1`, `C1`): variants of `A`/`E`/`F` fell through to `carconnected = 1` (reported connected with nothing attached), and `C1`/`D1` did not count as charging even though they're valid charging sub-states.

Fix: normalize the decoded state (`strip`/`upper`) and match by IEC 61851 state family prefix instead of exact string equality — `A*`/`E*`/`F*` (or empty) idle, `B*` connected, `C*`/`D*` charging.

## Testing

Verified locally on real AHP02-60227 hardware: Car Connected now correctly reports `False` with no vehicle attached. Verified against the simulator (mode3state `"C2"`) that connected/charging derivation is unchanged for the states already covered by tests.