### PR TITLE
Document AHP platform support

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![GitHub Release](https://img.shields.io/github/v/release/straybiker/alfen_modbus)](https://github.com/thastealth/alfen_modbus/releases)
 [![License](https://img.shields.io/github/license/thastealth/alfen_modbus)](LICENSE)
 
-Home Assistant integration for **Alfen Eve NG9xx** series EV chargers via Modbus TCP.
+Home Assistant integration for **Alfen Eve NG9xx** and **AHP** series EV chargers via Modbus TCP.
 
 ![Demo](demo.png)
 
@@ -22,11 +22,17 @@ Home Assistant integration for **Alfen Eve NG9xx** series EV chargers via Modbus
 ## Requirements
 
 - Home Assistant **2024.4.0** or newer
-- Alfen Eve NG9xx charger with:
-  - Firmware **4.2.0** or newer (Modbus TCP support)
-  - Firmware **6.4.0+** recommended (fixes power budget reset bug)
+- A supported Alfen charger (see [Supported Platforms](#supported-platforms)) with:
+  - The minimum firmware version for your platform
   - **Active Load Balancing** license enabled
 - Modbus TCP enabled on the charger
+
+## Supported Platforms
+
+| Platform | Minimum firmware | Notes |
+|----------|-------------------|-------|
+| Eve NG9xx | **4.2.0** (adds Modbus TCP support); **6.4.0+** recommended | Fixes a power budget reset bug — see Known Issues |
+| AHP (e.g. AHP02-60227) | **2.6.0** ([release notes](https://knowledge.alfen.com/categories/CAT-01021/KA-01635)) — currently the latest AHP firmware | Requires integration **v0.2.1+**; earlier versions fail every poll cycle because AHP rejects Modbus reads that don't align to register value boundaries ([#40](https://github.com/ThaStealth/alfen_modbus/issues/40)) |
 
 ## Installation
 
@@ -81,6 +87,7 @@ See the [Alfen Smart Charging Manual](https://knowledge.alfen.com/space/IN/63976
 
 - Power budget may reset to 0A when no car is connected (fixed in firmware [6.4.0-4210](https://knowledge.alfen.com/space/IN/243466257))
 - **Reallin power meter (post-2021)**: Chargers with a Reallin power meter produced after 2021 only export a subset of measurement values. Per-phase energy, apparent energy, and reactive energy sensors will show as "unavailable" (NaN). This is a hardware limitation, not a bug.
+- **AHP platform, integration < v0.2.1**: all entities stay unavailable because a single oversized Modbus read fails on every poll cycle. Update to v0.2.1 or newer ([#40](https://github.com/ThaStealth/alfen_modbus/issues/40)).
 
 ## Contributing
 

--- a/info.md
+++ b/info.md
@@ -3,6 +3,8 @@
 
 Home assistant Custom Component for reading data from Alfen EV charger through modbus TCP. Implements Inverter registers from  https://alfen.com/file-download/download/public/1610
 
+Supports both the **Eve NG9xx** and **AHP** charger platforms. AHP requires integration v0.2.1+ and firmware [2.6.0](https://knowledge.alfen.com/categories/CAT-01021/KA-01635) or newer.
+
 ### Features
 
 - Installation through Config Flow UI.


### PR DESCRIPTION
Adds a Supported Platforms section documenting AHP support alongside NG9xx:

- Minimum firmware **2.6.0** for AHP, linking Alfen's release notes (currently the latest AHP firmware release)
- Notes that AHP requires integration **v0.2.1+** (#40 / #43) — earlier versions fail every poll cycle
- Adds the same note to Known Issues and to `info.md` (HACS store description)

No code changes.