### PR TITLE
Move blocking Modbus connect/close I/O off the event loop

### DIFF
--- a/custom_components/alfen_modbus/__init__.py
+++ b/custom_components/alfen_modbus/__init__.py
@@ -61,7 +61,6 @@ type AlfenConfigEntry = ConfigEntry[AlfenModbusHub]
 
 async def async_setup(hass, config):
     """Set up the Alfen modbus component."""
-    hass.data[DOMAIN] = {}
     return True
 
 
@@ -115,11 +114,7 @@ async def async_unload_entry(hass, entry):
             ]
         )
     )
-    if not unload_ok:
-        return False
-
-    hass.data[DOMAIN].pop(entry.data["name"])
-    return True
+    return unload_ok
 
 
 def validate(value, comparison, against):
@@ -161,15 +156,17 @@ class AlfenModbusHub:
         self._refreshInterval = scan_interval
         self._scan_interval = timedelta(seconds=scan_interval)
         self._unsub_interval_method = None
-        self._sensors = []    
-        self._inputs = []    
+        self._sensors = []
+        self._inputs = []
         self.data = {}
+        self._closing = False
 
     @callback
     def async_add_alfen_sensor(self, update_callback, refresh_callback = None):
         """Listen for data updates."""
         # This is the first sensor, set up interval.
         if not self._sensors:
+            self._closing = False
             self._unsub_interval_method = async_track_time_interval(
                 self._hass, self.async_refresh_modbus_data, self._scan_interval
             )
@@ -191,6 +188,9 @@ class AlfenModbusHub:
             """stop the interval timer upon removal of last sensor"""
             self._unsub_interval_method()
             self._unsub_interval_method = None
+            # Block any read still in flight from silently reopening the
+            # connection after we close it below (pymodbus auto-connects).
+            self._closing = True
             # Close under the lock, off the event loop, so this can't race
             # an in-flight executor read/write on the same socket.
             self._hass.async_create_task(self._async_close())
@@ -241,8 +241,15 @@ class AlfenModbusHub:
 
         try:
             async with self._lock:
+                if self._closing:
+                    # Lost the race with teardown: the socket may already be
+                    # closed. Don't let pymodbus silently reopen it here, and
+                    # don't go through the reconnect-retry path below for it.
+                    return None
                 return await self._hass.async_add_executor_job(_do_read)
         except (BrokenPipeError, ConnectionError, OSError, ModbusException) as e:
+            if self._closing:
+                return None
             _LOGGER.warning("Connection error during read, attempting reconnect: %s", e)
             # Try to reconnect once
             def _do_reconnect_and_read():
@@ -285,8 +292,12 @@ class AlfenModbusHub:
 
         try:
             async with self._lock:
+                if self._closing:
+                    return None
                 return await self._hass.async_add_executor_job(_do_write)
         except (BrokenPipeError, ConnectionError, OSError, ModbusException) as e:
+            if self._closing:
+                return None
             _LOGGER.warning("Connection error during write, attempting reconnect: %s", e)
             # Try to reconnect once
             def _do_reconnect_and_write():
@@ -320,6 +331,8 @@ class AlfenModbusHub:
             
 
     async def read_modbus_data(self):
+        if self._closing:
+            return False
         return (
             await self.read_modbus_data_product()
             and await self.read_modbus_data_station()

--- a/custom_components/alfen_modbus/__init__.py
+++ b/custom_components/alfen_modbus/__init__.py
@@ -197,7 +197,10 @@ class AlfenModbusHub:
 
     async def _async_close(self):
         async with self._lock:
-            await self._hass.async_add_executor_job(self._client.close)
+            try:
+                await self._hass.async_add_executor_job(self._client.close)
+            except Exception:
+                pass
 
 
 
@@ -352,7 +355,7 @@ class AlfenModbusHub:
 
     async def read_modbus_data_station(self):
         status_data = await self.read_holding_registers(self._address,1100,6)
-        if status_data.isError():
+        if status_data is None or status_data.isError():
             return False
     
         self.data["actualMaxCurrent"] =  round(self.decode_from_registers(status_data.registers,0,2,self._client.DATATYPE.FLOAT32),2)
@@ -364,7 +367,7 @@ class AlfenModbusHub:
     async def read_modbus_data_scn(self):
         if(self.has_scn):
             status_data = await self.read_holding_registers(self._address,1400,32)
-            if status_data.isError():
+            if status_data is None or status_data.isError():
                 return False
 
             self.data["scnName"] = self.decode_from_registers(status_data.registers,0,4,self._client.DATATYPE.STRING).strip('\x00')
@@ -441,7 +444,7 @@ class AlfenModbusHub:
                                             
                             
             status_data = await self.read_holding_registers(socket,1200,16)
-            if status_data.isError():
+            if status_data is None or status_data.isError():
                 return False
   
             self.data["socket_"+str(socket)+"_available"] =  self.decode_from_registers(status_data.registers, 0, 1,self._client.DATATYPE.UINT16) 
@@ -480,7 +483,7 @@ class AlfenModbusHub:
         
     async def read_modbus_data_product(self):
         identification_data = await self.read_holding_registers(self._address, 100, 79)
-        if identification_data.isError():
+        if identification_data is None or identification_data.isError():
             return False
 
         self.data["name"] = self.decode_from_registers(identification_data.registers, 0, 17, self._client.DATATYPE.STRING).strip('\x00')

--- a/custom_components/alfen_modbus/__init__.py
+++ b/custom_components/alfen_modbus/__init__.py
@@ -8,12 +8,14 @@ from typing import Optional
 
 import voluptuous as vol
 from pymodbus.client import ModbusTcpClient
+from pymodbus.exceptions import ModbusException
 
 import homeassistant.helpers.config_validation as cv
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_NAME, CONF_HOST, CONF_PORT, CONF_SCAN_INTERVAL
 from homeassistant.core import HomeAssistant
 from homeassistant.core import callback
+from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers.event import async_track_time_interval
 from .const import (
     DOMAIN,
@@ -88,9 +90,16 @@ async def async_setup_entry(hass: HomeAssistant, entry: AlfenConfigEntry):
     """Register the hub."""
     entry.runtime_data = hub
 
-    # Read device info before setting up platforms so device_info is available
-    hub.connect()
-    await hub.read_modbus_data()
+    # Read device info before setting up platforms so device_info is available.
+    # Connecting happens lazily inside read_modbus_data (off the event loop).
+    # Only treat connection-level failures as "not ready yet" (HA will retry
+    # setup automatically); anything else is a real bug and should surface
+    # as a normal traceback instead of retrying forever.
+    try:
+        await hub.read_modbus_data()
+    except (ConnectionError, OSError, ModbusException) as err:
+        _LOGGER.exception("Unable to connect to %s:%s", host, port)
+        raise ConfigEntryNotReady(f"Unable to connect to {host}:{port}") from err
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     return True
@@ -161,11 +170,11 @@ class AlfenModbusHub:
         """Listen for data updates."""
         # This is the first sensor, set up interval.
         if not self._sensors:
-            self.connect()
             self._unsub_interval_method = async_track_time_interval(
                 self._hass, self.async_refresh_modbus_data, self._scan_interval
             )
-            # Schedule initial data read as a task (non-blocking)
+            # Schedule initial data read as a task (non-blocking); pymodbus's
+            # sync client connects on demand from within that executor job.
             self._hass.async_create_task(self.read_modbus_data())
 
         self._sensors.append(update_callback)
@@ -182,7 +191,13 @@ class AlfenModbusHub:
             """stop the interval timer upon removal of last sensor"""
             self._unsub_interval_method()
             self._unsub_interval_method = None
-            self.close()
+            # Close under the lock, off the event loop, so this can't race
+            # an in-flight executor read/write on the same socket.
+            self._hass.async_create_task(self._async_close())
+
+    async def _async_close(self):
+        async with self._lock:
+            await self._hass.async_add_executor_job(self._client.close)
 
 
 
@@ -207,35 +222,6 @@ class AlfenModbusHub:
         """Return the name of this hub."""
         return self._name
 
-    def close(self):
-        """Disconnect client."""
-        self._client.close()
-
-    def connect(self):
-        """Connect client."""
-        self._client.connect()
-
-    def _ensure_connected(self):
-        """Ensure the modbus client is connected, reconnect if necessary.
-        Must be called while holding self._lock."""
-        try:
-            # Check if socket is open (method may vary by pymodbus version)
-            is_open = getattr(self._client, 'is_socket_open', None)
-            if is_open and not is_open():
-                _LOGGER.debug("Modbus connection lost, reconnecting...")
-                try:
-                    self._client.close()
-                except Exception:
-                    pass  # Ignore errors when closing
-                self._client.connect()
-                # Verify reconnection
-                if is_open and not is_open():
-                    raise ConnectionError("Failed to reconnect to modbus device")
-        except AttributeError:
-            # If is_socket_open doesn't exist, just try to connect
-            # The actual read/write will catch connection errors
-            pass
-
     @property
     def has_socket_2(self):
         """Return true if a meter is available"""
@@ -248,25 +234,28 @@ class AlfenModbusHub:
 
     async def read_holding_registers(self, unit, address, count):
         """Read holding registers."""
+        def _do_read():
+            # Runs in the executor thread, off the event loop: pymodbus's
+            # sync client connects on demand inside read_holding_registers.
+            return self._client.read_holding_registers(address=address, count=count, device_id=unit)
+
         try:
             async with self._lock:
-                self._ensure_connected()
-                return await self._hass.async_add_executor_job(
-                    lambda: self._client.read_holding_registers(address=address, count=count, device_id=unit)
-                )
-        except (BrokenPipeError, ConnectionError, OSError) as e:
+                return await self._hass.async_add_executor_job(_do_read)
+        except (BrokenPipeError, ConnectionError, OSError, ModbusException) as e:
             _LOGGER.warning("Connection error during read, attempting reconnect: %s", e)
             # Try to reconnect once
+            def _do_reconnect_and_read():
+                try:
+                    self._client.close()
+                except Exception:
+                    pass
+                self._client.connect()
+                return self._client.read_holding_registers(address=address, count=count, device_id=unit)
+
             try:
                 async with self._lock:
-                    try:
-                        self._client.close()
-                    except Exception:
-                        pass
-                    self._client.connect()
-                    return await self._hass.async_add_executor_job(
-                        lambda: self._client.read_holding_registers(address=address, count=count, device_id=unit)
-                    )
+                    return await self._hass.async_add_executor_job(_do_reconnect_and_read)
             except Exception as retry_error:
                 _LOGGER.error("Failed to reconnect and retry read: %s", retry_error)
                 raise
@@ -289,25 +278,28 @@ class AlfenModbusHub:
 
     async def write_registers(self, unit, address, payload):
         """Write registers."""
+        def _do_write():
+            # Runs in the executor thread, off the event loop: pymodbus's
+            # sync client connects on demand inside write_registers.
+            return self._client.write_registers(address=address, values=payload, device_id=unit)
+
         try:
             async with self._lock:
-                self._ensure_connected()
-                return await self._hass.async_add_executor_job(
-                    lambda: self._client.write_registers(address=address, values=payload, device_id=unit)
-                )
-        except (BrokenPipeError, ConnectionError, OSError) as e:
+                return await self._hass.async_add_executor_job(_do_write)
+        except (BrokenPipeError, ConnectionError, OSError, ModbusException) as e:
             _LOGGER.warning("Connection error during write, attempting reconnect: %s", e)
             # Try to reconnect once
+            def _do_reconnect_and_write():
+                try:
+                    self._client.close()
+                except Exception:
+                    pass
+                self._client.connect()
+                return self._client.write_registers(address=address, values=payload, device_id=unit)
+
             try:
                 async with self._lock:
-                    try:
-                        self._client.close()
-                    except Exception:
-                        pass
-                    self._client.connect()
-                    return await self._hass.async_add_executor_job(
-                        lambda: self._client.write_registers(address=address, values=payload, device_id=unit)
-                    )
+                    return await self._hass.async_add_executor_job(_do_reconnect_and_write)
             except Exception as retry_error:
                 _LOGGER.error("Failed to reconnect and retry write: %s", retry_error)
                 raise


### PR DESCRIPTION
Looked into #39 (unreachable device stalls HA's bootstrap timeout) and #28/#20 (transaction-id mismatch, connection closed abruptly) to see what could actually be fixed in code.

**Verified (against pymodbus 3.11.2 source, not hardware):**
- `hub.connect()`/`self.connect()` were called directly on the event loop (in `async_setup_entry` and the `@callback` `async_add_alfen_sensor`), and were **not** protected by `self._lock` — they could run concurrently with a lock-protected executor thread mid-read/write on the same non-thread-safe socket.
- `_ensure_connected()`'s `getattr(self._client, 'is_socket_open', None)` was always `None`: pymodbus 3.x only exposes a `connected` property, not `is_socket_open`. It was a no-op.
- pymodbus's sync client already connects on demand inside `execute()` (`if not self.connect(): raise ConnectionException(...)`), so removing the redundant explicit connects doesn't break connectivity — it just moves the *only* connect into the executor thread, under the lock, where the read/write already run.
- `pymodbus.exceptions.ConnectionException` (and `ModbusException` generally) is **not** a subclass of the builtin `ConnectionError`/`OSError`, so the existing reconnect-retry clauses in `read_holding_registers`/`write_registers` never caught pymodbus's own connection exceptions — only raw socket errors.
- `async_unload_entry` did `hass.data[DOMAIN].pop(entry.data["name"])`, but nothing has written to that dict since the `entry.runtime_data` migration (#47/#32) — `async_setup` only ever sets it to `{}`. **Every unload/reload raised `KeyError`.**

**Changes:**
- Read/write now do connect+call entirely inside the executor job (removed the dead `_ensure_connected()`/`connect()` wrapper).
- Removed the unlocked blocking `connect()` calls from `async_setup_entry` and `async_add_alfen_sensor`.
- `async_remove_alfen_sensor`'s `close()` now also runs under the lock via the executor, for the same race-condition reason.
- Added a `_closing` flag so a read/write already queued on the lock when the last sensor is removed can't dispatch to the executor (or run the reconnect-retry path) after the socket has been closed — otherwise pymodbus's auto-connect could silently reopen a session that nothing would ever close again. In that window `read_holding_registers`/`write_registers` now return `None` instead of raising (raising would have routed through the reconnect-retry path, exactly what this is meant to avoid). The four `read_modbus_data_*` call sites that used the result now guard with `is None or ...isError()` accordingly.
- Reconnect-retry clauses now also catch `ModbusException`.
- `async_setup_entry` raises `ConfigEntryNotReady` on a connection failure during the initial read (HA retries setup automatically) instead of leaving the entry in a permanent error state — other exceptions (e.g. corrupt register data) still surface as real tracebacks instead of being swallowed into an infinite "not ready" retry.
- Removed the now-dead `hass.data[DOMAIN]` usage (see above) that made every unload/reload raise `KeyError`.

**Not claiming this fixes #39/#28/#20** — I can't run Home Assistant or the actual hardware here. This addresses real, verifiable anti-patterns (blocking I/O on the event loop, unlocked concurrent socket access, a guaranteed unload crash) that are plausible contributing causes for all three, but leaving those issues open for the reporters to confirm against a real device.