### PR TITLE
Fix all Ruff lint findings

### DIFF
--- a/custom_components/alfen_modbus/__init__.py
+++ b/custom_components/alfen_modbus/__init__.py
@@ -197,7 +197,7 @@ class AlfenModbusHub:
         async with self._lock:
             try:
                 await self._hass.async_add_executor_job(self._client.close)
-            except (OSError, ModbusException) as err:
+            except Exception as err:  # noqa: BLE001 - teardown must never raise
                 _LOGGER.debug("Error closing Modbus client: %s", err)
 
 

--- a/custom_components/alfen_modbus/__init__.py
+++ b/custom_components/alfen_modbus/__init__.py
@@ -2,34 +2,32 @@
 import asyncio
 import logging
 import operator
-from datetime import datetime, timedelta  
-from dateutil.tz import tzoffset
-from typing import Optional
+from datetime import datetime, timedelta
 
+import homeassistant.helpers.config_validation as cv
 import voluptuous as vol
+from dateutil.tz import tzoffset
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_HOST, CONF_NAME, CONF_PORT, CONF_SCAN_INTERVAL
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.exceptions import ConfigEntryNotReady
+from homeassistant.helpers.event import async_track_time_interval
 from pymodbus.client import ModbusTcpClient
 from pymodbus.exceptions import ModbusException
 
-import homeassistant.helpers.config_validation as cv
-from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_NAME, CONF_HOST, CONF_PORT, CONF_SCAN_INTERVAL
-from homeassistant.core import HomeAssistant
-from homeassistant.core import callback
-from homeassistant.exceptions import ConfigEntryNotReady
-from homeassistant.helpers.event import async_track_time_interval
 from .const import (
-    DOMAIN,
-    DEFAULT_NAME,
-    DEFAULT_SCAN_INTERVAL,
-    DEFAULT_MODBUS_ADDRESS,
     CONF_MODBUS_ADDRESS,
     CONF_READ_SCN,
     CONF_READ_SOCKET2,
+    CONTROL_PHASE_MODES,
+    DEFAULT_MODBUS_ADDRESS,
+    DEFAULT_NAME,
     DEFAULT_READ_SCN,
     DEFAULT_READ_SOCKET2,
-    VALID_TIME_S,
+    DEFAULT_SCAN_INTERVAL,
+    DOMAIN,
     MAX_CURRENT_S,
-    CONTROL_PHASE_MODES
+    VALID_TIME_S,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -199,19 +197,19 @@ class AlfenModbusHub:
         async with self._lock:
             try:
                 await self._hass.async_add_executor_job(self._client.close)
-            except Exception:
-                pass
+            except (OSError, ModbusException) as err:
+                _LOGGER.debug("Error closing Modbus client: %s", err)
 
 
 
-    async def async_refresh_modbus_data(self, _now: Optional[int] = None) -> None:
+    async def async_refresh_modbus_data(self, _now: int | None = None) -> None:
         """Time to update."""
         if not self._sensors:
             return
 
         try:
             update_result = await self.read_modbus_data()
-        except Exception as e:
+        except Exception:
             _LOGGER.exception("Error reading modbus data")
             update_result = False
 
@@ -258,8 +256,8 @@ class AlfenModbusHub:
             def _do_reconnect_and_read():
                 try:
                     self._client.close()
-                except Exception:
-                    pass
+                except (OSError, ModbusException) as close_err:
+                    _LOGGER.debug("Error closing Modbus client before reconnect: %s", close_err)
                 self._client.connect()
                 return self._client.read_holding_registers(address=address, count=count, device_id=unit)
 
@@ -306,8 +304,8 @@ class AlfenModbusHub:
             def _do_reconnect_and_write():
                 try:
                     self._client.close()
-                except Exception:
-                    pass
+                except (OSError, ModbusException) as close_err:
+                    _LOGGER.debug("Error closing Modbus client before reconnect: %s", close_err)
                 self._client.connect()
                 return self._client.write_registers(address=address, values=payload, device_id=unit)
 

--- a/custom_components/alfen_modbus/binary_sensor.py
+++ b/custom_components/alfen_modbus/binary_sensor.py
@@ -2,15 +2,14 @@
 import logging
 
 from homeassistant.components.binary_sensor import (
-    BinarySensorEntity,
     BinarySensorDeviceClass,
+    BinarySensorEntity,
     BinarySensorEntityDescription,
 )
 from homeassistant.const import CONF_NAME, EntityCategory
-from homeassistant.core import callback
 
 from . import AlfenConfigEntry
-from .const import DOMAIN, DEFAULT_MANUFACTURER
+from .const import DEFAULT_MANUFACTURER, DOMAIN
 from .entity import AlfenEntity
 
 _LOGGER = logging.getLogger(__name__)

--- a/custom_components/alfen_modbus/config_flow.py
+++ b/custom_components/alfen_modbus/config_flow.py
@@ -3,23 +3,23 @@ import logging
 import re
 
 import voluptuous as vol
+from homeassistant import config_entries
+from homeassistant.const import CONF_HOST, CONF_NAME, CONF_PORT, CONF_SCAN_INTERVAL
+from homeassistant.core import HomeAssistant, callback
 from pymodbus.client import ModbusTcpClient
 
-from homeassistant import config_entries
-from homeassistant.const import CONF_NAME, CONF_HOST, CONF_PORT, CONF_SCAN_INTERVAL
 from .const import (
-    DOMAIN,
-    DEFAULT_NAME,
-    DEFAULT_SCAN_INTERVAL,
-    DEFAULT_PORT,
-    DEFAULT_MODBUS_ADDRESS,
     CONF_MODBUS_ADDRESS,
     CONF_READ_SCN,
     CONF_READ_SOCKET2,
+    DEFAULT_MODBUS_ADDRESS,
+    DEFAULT_NAME,
+    DEFAULT_PORT,
     DEFAULT_READ_SCN,
     DEFAULT_READ_SOCKET2,
+    DEFAULT_SCAN_INTERVAL,
+    DOMAIN,
 )
-from homeassistant.core import HomeAssistant, callback
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -56,7 +56,7 @@ async def async_test_connection(hass: HomeAssistant, host: str, port: int) -> bo
             await hass.async_add_executor_job(client.close)
             return True
         return False
-    except Exception as e:
+    except Exception as e:  # noqa: BLE001 - any failure means "can't connect"
         _LOGGER.debug("Connection test failed: %s", e)
         return False
 
@@ -64,9 +64,9 @@ async def async_test_connection(hass: HomeAssistant, host: str, port: int) -> bo
 @callback
 def alfen_modbus_entries(hass: HomeAssistant):
     """Return the hosts already configured."""
-    return set(
+    return {
         entry.data[CONF_HOST] for entry in hass.config_entries.async_entries(DOMAIN)
-    )
+    }
 
 
 class AlfenModbusConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
@@ -83,9 +83,7 @@ class AlfenModbusConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     def _host_in_configuration_exists(self, host) -> bool:
         """Return True if host exists in configuration."""
-        if host in alfen_modbus_entries(self.hass):
-            return True
-        return False
+        return host in alfen_modbus_entries(self.hass)
 
     async def async_step_user(self, user_input=None):
         """Handle the initial step."""
@@ -127,9 +125,10 @@ class AlfenModbusOptionsFlowHandler(config_entries.OptionsFlow):
             new_host = user_input.get(CONF_HOST, current_host)
             new_port = user_input.get(CONF_PORT, current_port)
 
-            if new_host != current_host or new_port != current_port:
-                if not await async_test_connection(self.hass, new_host, new_port):
-                    errors["base"] = "cannot_connect"
+            if (new_host != current_host or new_port != current_port) and not await async_test_connection(
+                self.hass, new_host, new_port
+            ):
+                errors["base"] = "cannot_connect"
 
             if not errors:
                 # Merge options into data for reload

--- a/custom_components/alfen_modbus/entity.py
+++ b/custom_components/alfen_modbus/entity.py
@@ -2,7 +2,7 @@
 
 from homeassistant.core import callback
 from homeassistant.helpers.device_registry import DeviceInfo
-from homeassistant.helpers.entity import Entity, EntityDescription
+from homeassistant.helpers.entity import Entity
 
 from . import AlfenModbusHub
 

--- a/custom_components/alfen_modbus/number.py
+++ b/custom_components/alfen_modbus/number.py
@@ -1,15 +1,13 @@
 import logging
-from typing import Optional, Dict, Any
 
 from homeassistant.components.number import NumberEntity
 from homeassistant.const import CONF_NAME
-from homeassistant.core import callback
 
 from . import AlfenConfigEntry
 from .const import (
-    DOMAIN,
     ATTR_MANUFACTURER,
     CONTROL_SLAVE_MAX_CURRENT,
+    DOMAIN,
     MAX_CURRENT_S,
 )
 from .entity import AlfenEntity
@@ -86,11 +84,11 @@ class AlfenNumber(AlfenEntity, NumberEntity):
         self._fmt = fmt
         self._attr_native_min_value = attrs["min"]
         self._attr_native_max_value = attrs["max"]
-        if "unit" in attrs.keys():
+        if "unit" in attrs:
             self._attr_native_unit_of_measurement = attrs["unit"]
-        if "mode" in attrs.keys():
+        if "mode" in attrs:
             self._attr_mode = attrs["mode"]
-        if "step" in attrs.keys():
+        if "step" in attrs:
             self._attr_native_step = attrs["step"]
 
     async def async_added_to_hass(self) -> None:
@@ -106,7 +104,7 @@ class AlfenNumber(AlfenEntity, NumberEntity):
         return f"{self._platform_name} {self._name}"
 
     @property
-    def unique_id(self) -> Optional[str]:
+    def unique_id(self) -> str | None:
         return f"{self._platform_name}_{self._key}"
 
     @property

--- a/custom_components/alfen_modbus/select.py
+++ b/custom_components/alfen_modbus/select.py
@@ -1,15 +1,13 @@
 import logging
-from typing import Optional, Dict, Any
 
 from homeassistant.components.select import SelectEntity
 from homeassistant.const import CONF_NAME
-from homeassistant.core import callback
 
 from . import AlfenConfigEntry
 from .const import (
-    DOMAIN,
     ATTR_MANUFACTURER,
     CONTROL_PHASE,
+    DOMAIN,
 )
 from .entity import AlfenEntity
 
@@ -96,7 +94,7 @@ class AlfenSelect(AlfenEntity, SelectEntity):
         return f"{self._platform_name} {self._name}"
 
     @property
-    def unique_id(self) -> Optional[str]:
+    def unique_id(self) -> str | None:
         return f"{self._platform_name}_{self._key}"
 
     @property

--- a/custom_components/alfen_modbus/sensor.py
+++ b/custom_components/alfen_modbus/sensor.py
@@ -1,28 +1,26 @@
 import logging
-from typing import Optional, Dict, Any
+
+from homeassistant.components.sensor import (
+    SensorDeviceClass,
+    SensorEntity,
+    SensorStateClass,
+)
+from homeassistant.const import CONF_NAME, UnitOfEnergy, UnitOfPower
+
+from . import AlfenConfigEntry
 from .const import (
-    SENSOR_TYPES,
-    SOCKET1_SENSOR_TYPES,
-    SOCKET2_SENSOR_TYPES,
-    SCN_SENSOR_TYPES,
-    DOMAIN,
-    METER_TYPE,
-    METER_STATE_MODES,
+    ATTR_MANUFACTURER,
     AVAILABILITY_MODES,
     BOOLEAN_EXPLAINED,
     CONTROL_PHASE_MODES,
-    ATTR_MANUFACTURER,
+    DOMAIN,
+    METER_STATE_MODES,
+    METER_TYPE,
+    SCN_SENSOR_TYPES,
+    SENSOR_TYPES,
+    SOCKET1_SENSOR_TYPES,
+    SOCKET2_SENSOR_TYPES,
 )
-from homeassistant.const import CONF_NAME, UnitOfEnergy, UnitOfPower
-from homeassistant.components.sensor import (
-    SensorStateClass,
-    SensorEntity,
-    SensorDeviceClass
-)
-
-from homeassistant.core import callback
-
-from . import AlfenConfigEntry
 from .entity import AlfenEntity
 
 _LOGGER = logging.getLogger(__name__)
@@ -102,9 +100,8 @@ class AlfenSensor(AlfenEntity, SensorEntity):
         super().__init__(hub, device_info)
         self._platform_name = platform_name
         self._key = key
-        if not hub.has_socket_2:
-            if name.startswith("S1 "):
-                name = name.replace("S1 ","")
+        if not hub.has_socket_2 and name.startswith("S1 "):
+            name = name.replace("S1 ","")
         self._name = name
         self._unit_of_measurement = unit
         self._icon = icon
@@ -122,7 +119,7 @@ class AlfenSensor(AlfenEntity, SensorEntity):
         return f"{self._platform_name} {self._name}"
 
     @property
-    def unique_id(self) -> Optional[str]:
+    def unique_id(self) -> str | None:
         return f"{self._platform_name}_{self._key}"
 
     @property

--- a/simulator/address_test.py
+++ b/simulator/address_test.py
@@ -1,8 +1,13 @@
 """Test script to verify exact addressing behavior of pymodbus 3.11.4"""
 import asyncio
-from pymodbus.server import StartAsyncTcpServer
-from pymodbus.datastore import ModbusSequentialDataBlock, ModbusServerContext, ModbusDeviceContext
+
 from pymodbus.client import AsyncModbusTcpClient
+from pymodbus.datastore import (
+    ModbusDeviceContext,
+    ModbusSequentialDataBlock,
+    ModbusServerContext,
+)
+from pymodbus.server import StartAsyncTcpServer
 
 PORT = 5021  # Use different port to avoid conflicts
 

--- a/simulator/debug_5020.py
+++ b/simulator/debug_5020.py
@@ -1,5 +1,6 @@
 """Debug script to test the actual simulator on port 5020"""
 import asyncio
+
 from pymodbus.client import AsyncModbusTcpClient
 
 PORT = 5020
@@ -34,7 +35,7 @@ async def run():
             try:
                 val = struct.unpack('>f', b)[0]
                 print(f"  Register {addr}: {val:.2f}")
-            except:
+            except struct.error:
                 print(f"  Register {addr}: {b.hex()}")
     
     client.close()

--- a/simulator/debug_read.py
+++ b/simulator/debug_read.py
@@ -1,5 +1,7 @@
 import asyncio
+
 from pymodbus.client import AsyncModbusTcpClient
+
 
 async def debug_read():
     client = AsyncModbusTcpClient("127.0.0.1", port=5020)

--- a/simulator/debug_registers.py
+++ b/simulator/debug_registers.py
@@ -1,8 +1,10 @@
 """Debug script to dump raw register values and find actual data locations."""
+import argparse
 import asyncio
 import struct
-import argparse
+
 from pymodbus.client import AsyncModbusTcpClient
+
 
 async def debug_registers(port):
     client = AsyncModbusTcpClient("127.0.0.1", port=port)
@@ -16,7 +18,7 @@ async def debug_registers(port):
         b = b''.join(r.to_bytes(2, 'big') for r in regs)
         return struct.unpack('>f', b)[0]
     
-    print(f"\n=== Unit 1 Socket: Scanning registers 300-330 for voltage data ===")
+    print("\n=== Unit 1 Socket: Scanning registers 300-330 for voltage data ===")
     print("Looking for voltage values around 230V...")
     
     for base in range(300, 330, 2):
@@ -27,13 +29,13 @@ async def debug_registers(port):
             marker = " <-- LINE VOLTAGE!" if 380 < val < 420 else marker
             print(f"  Reg {base}: {val:.2f}{marker}")
     
-    print(f"\n=== Unit 1 Socket: Scanning registers 1200-1220 for status data ===")
+    print("\n=== Unit 1 Socket: Scanning registers 1200-1220 for status data ===")
     rr = await client.read_holding_registers(1200, count=20, device_id=1)
     if not rr.isError():
         for i, val in enumerate(rr.registers):
             print(f"  Reg {1200+i}: {val} (0x{val:04x})")
     
-    print(f"\n=== Unit 200 Product: Scanning registers 1100-1110 for station data ===")
+    print("\n=== Unit 200 Product: Scanning registers 1100-1110 for station data ===")
     rr = await client.read_holding_registers(1100, count=10, device_id=200)
     if not rr.isError():
         for i in range(0, len(rr.registers), 2):

--- a/simulator/simulator.py
+++ b/simulator/simulator.py
@@ -15,17 +15,22 @@ Register addressing:
   at block[N] to have it appear at register N+1 from client's perspective.
   Therefore, to have client read register N, we store at block[N-1].
 """
+import argparse
 import asyncio
 import logging
+import os
 import struct
-import argparse
 import subprocess
 import sys
-import os
-from pymodbus.server import StartAsyncTcpServer
-from pymodbus.datastore import ModbusSequentialDataBlock, ModbusServerContext, ModbusDeviceContext
+
 from pymodbus.constants import ExcCodes
+from pymodbus.datastore import (
+    ModbusDeviceContext,
+    ModbusSequentialDataBlock,
+    ModbusServerContext,
+)
 from pymodbus.pdu.device import ModbusDeviceIdentification
+from pymodbus.server import StartAsyncTcpServer
 
 # Default Configuration - matches real Alfen hardware
 DEFAULT_PORT = 502  # Standard Modbus TCP port
@@ -45,10 +50,10 @@ def kill_ghost_processes(port):
         try:
             # Find process using the port
             result = subprocess.run(
-                ['powershell', '-Command', 
-                 f'Get-NetTCPConnection -LocalPort {port} -ErrorAction SilentlyContinue | '
-                 f'Select-Object -ExpandProperty OwningProcess'],
-                capture_output=True, text=True, timeout=5
+                ['powershell', '-Command',
+                 (f'Get-NetTCPConnection -LocalPort {port} -ErrorAction SilentlyContinue | '
+                  'Select-Object -ExpandProperty OwningProcess')],
+                capture_output=True, text=True, timeout=5, check=False
             )
             pids = [pid.strip() for pid in result.stdout.strip().split('\n') if pid.strip()]
             
@@ -58,8 +63,8 @@ def kill_ghost_processes(port):
                     pid_int = int(pid)
                     if pid_int != current_pid:
                         log.warning(f"Killing ghost process {pid_int} on port {port}")
-                        subprocess.run(['taskkill', '/F', '/PID', str(pid_int)], 
-                                      capture_output=True, timeout=5)
+                        subprocess.run(['taskkill', '/F', '/PID', str(pid_int)],
+                                      capture_output=True, timeout=5, check=False)
                 except (ValueError, subprocess.TimeoutExpired):
                     pass
                     
@@ -67,14 +72,14 @@ def kill_ghost_processes(port):
                 import time
                 time.sleep(1)  # Wait for port to be released
                 
-        except Exception as e:
+        except Exception as e:  # noqa: BLE001 - best-effort cleanup, never fatal
             log.debug(f"Ghost process check failed (non-critical): {e}")
     else:
         # Linux/Mac: use lsof
         try:
             result = subprocess.run(
                 ['lsof', '-ti', f':{port}'],
-                capture_output=True, text=True, timeout=5
+                capture_output=True, text=True, timeout=5, check=False
             )
             pids = [pid.strip() for pid in result.stdout.strip().split('\n') if pid.strip()]
             
@@ -92,7 +97,7 @@ def kill_ghost_processes(port):
                 import time
                 time.sleep(1)
                 
-        except Exception as e:
+        except Exception as e:  # noqa: BLE001 - best-effort cleanup, never fatal
             log.debug(f"Ghost process check failed (non-critical): {e}")
 
 # ============================================================================
@@ -208,7 +213,7 @@ def setup_product_context():
     
     # Time registers (168-178)
     import datetime
-    now = datetime.datetime.now()
+    now = datetime.datetime.now()  # noqa: DTZ005 - simulates the charger's local wall clock
     block.setValues(reg(168), encode_int16(now.year))
     block.setValues(reg(169), encode_int16(now.month))
     block.setValues(reg(170), encode_int16(now.day))
@@ -347,8 +352,8 @@ async def update_simulation(context):
                 if isinstance(values, list) and len(values) == 2:
                     # Write to Actual Applied Max Current (register 1206)
                     slave.setValues(3, 1206, values)
-            except Exception:
-                pass
+            except Exception as err:  # noqa: BLE001 - keep the mirror loop alive
+                log.debug("Max current mirror failed for unit %s: %s", unit, err)
 
 # ============================================================================
 # Main
@@ -374,9 +379,9 @@ async def run_server(port):
     identity.MajorMinorRevision = '5.16.0'
 
     log.info(f"Starting Alfen Eve Simulator on port {port}...")
-    log.info(f"  Unit 200: Product/Station information")
-    log.info(f"  Unit 1: Socket 1")
-    log.info(f"  Unit 2: Socket 2")
+    log.info("  Unit 200: Product/Station information")
+    log.info("  Unit 1: Socket 1")
+    log.info("  Unit 2: Socket 2")
     
     server_task = asyncio.create_task(StartAsyncTcpServer(
         context=store,

--- a/simulator/smoke_test_ha.py
+++ b/simulator/smoke_test_ha.py
@@ -7,10 +7,12 @@ work correctly against the simulator.
 
 Based on: alfen_modbus/custom_components/alfen_modbus/__init__.py
 """
+import argparse
 import asyncio
 import logging
 import struct
-import argparse
+import sys
+
 from pymodbus.client import AsyncModbusTcpClient
 
 # Configuration - matches HA integration defaults
@@ -103,7 +105,7 @@ async def test_product_data(client, unit, result):
     
     This is called from: read_modbus_data_product() in __init__.py
     """
-    log.info("\n=== Test: Product Data (Unit %d, Registers 100-178) ===" % unit)
+    log.info("\n=== Test: Product Data (Unit %d, Registers 100-178) ===", unit)
     
     rr = await client.read_holding_registers(100, count=79, device_id=unit)
     if rr.isError():
@@ -155,7 +157,7 @@ async def test_station_data(client, unit, result):
     
     This is called from: read_modbus_data_station() in __init__.py
     """
-    log.info("\n=== Test: Station Status (Unit %d, Registers 1100-1105) ===" % unit)
+    log.info("\n=== Test: Station Status (Unit %d, Registers 1100-1105) ===", unit)
     
     rr = await client.read_holding_registers(1100, count=6, device_id=unit)
     if rr.isError():
@@ -191,7 +193,7 @@ async def test_socket_energy_data(client, socket_id, result):
     This is called from: read_modbus_data_socket() in __init__.py
     Socket 1 uses unit=1, Socket 2 uses unit=2
     """
-    log.info("\n=== Test: Socket %d Energy Data (Unit %d, Registers 300-425) ===" % (socket_id, socket_id))
+    log.info("\n=== Test: Socket %d Energy Data (Unit %d, Registers 300-425) ===", socket_id, socket_id)
 
     # Read as two value-aligned chunks (300-361, 362-425); the 126-register
     # block exceeds the FC3 125-register limit and firmware rejects reads
@@ -239,6 +241,7 @@ async def test_socket_energy_data(client, socket_id, result):
     e_delivered_sum = round(decode_float64(regs, 74), 2)
     
     log.info(f"  Meter State: {meter_state}")
+    log.info(f"  Meter Age: {meter_age}ms, Meter Type: {meter_type}")
     log.info(f"  Voltages L-N: {v_l1n}V, {v_l2n}V, {v_l3n}V")
     log.info(f"  Voltages L-L: {v_l1l2}V, {v_l2l3}V, {v_l3l1}V")
     log.info(f"  Currents: N={i_n}A, L1={i_l1}A, L2={i_l2}A, L3={i_l3}A, Sum={i_sum}A")
@@ -249,6 +252,7 @@ async def test_socket_energy_data(client, socket_id, result):
     
     # Validations
     result.check("Meter State defined", meter_state in range(16))
+    result.check("Meter Type defined", meter_type in range(5))
     result.check_range("Voltage L1-N", v_l1n, 200, 260)
     result.check_range("Voltage L2-N", v_l2n, 200, 260)
     result.check_range("Voltage L3-N", v_l3n, 200, 260)
@@ -266,7 +270,7 @@ async def test_socket_status_data(client, socket_id, result):
     
     This is the second part of read_modbus_data_socket() in __init__.py
     """
-    log.info("\n=== Test: Socket %d Status (Unit %d, Registers 1200-1215) ===" % (socket_id, socket_id))
+    log.info("\n=== Test: Socket %d Status (Unit %d, Registers 1200-1215) ===", socket_id, socket_id)
     
     rr = await client.read_holding_registers(1200, count=16, device_id=socket_id)
     if rr.isError():
@@ -307,7 +311,7 @@ async def test_socket_status_data(client, socket_id, result):
     car_connected = 0 if mode3_state in ["A", "E", "F"] else 1
     car_charging = 1 if mode3_state in ["C2", "D2"] else 0
     
-    log.info(f"  --- Binary Sensor Derivation ---")
+    log.info("  --- Binary Sensor Derivation ---")
     log.info(f"  Car Connected: {car_connected} (derived from mode3_state='{mode3_state}')")
     log.info(f"  Car Charging: {car_charging} (derived from mode3_state='{mode3_state}')")
     
@@ -324,7 +328,7 @@ async def test_write_max_current(client, socket_id, result):
     
     This replicates the write operation from the HA number entity
     """
-    log.info("\n=== Test: Write Max Current (Socket %d, Register 1210) ===" % socket_id)
+    log.info("\n=== Test: Write Max Current (Socket %d, Register 1210) ===", socket_id)
     
     test_current = 14.5
     
@@ -416,7 +420,7 @@ def main():
     args = parser.parse_args()
     
     success = asyncio.run(run_smoke_tests(args.port))
-    exit(0 if success else 1)
+    sys.exit(0 if success else 1)
 
 
 if __name__ == "__main__":

--- a/simulator/test_real_alfen.py
+++ b/simulator/test_real_alfen.py
@@ -9,6 +9,8 @@ Configuration:
 """
 import logging
 import struct
+import sys
+
 from pymodbus.client import ModbusTcpClient
 
 # Import local config (gitignored)
@@ -19,7 +21,7 @@ except ImportError:
     print("Create local_config.py with:")
     print('  ALFEN_HOST = "YOUR_CHARGER_IP"')
     print('  ALFEN_PORT = 502')
-    exit(1)
+    sys.exit(1)
 
 # Logging setup
 logging.basicConfig(level=logging.INFO, format='%(message)s')

--- a/simulator/test_simulator.py
+++ b/simulator/test_simulator.py
@@ -3,10 +3,12 @@ Test script for Alfen Eve Single Pro Modbus Simulator
 
 Verifies the simulator responds correctly with expected values.
 """
+import argparse
 import asyncio
 import logging
 import struct
-import argparse
+import sys
+
 from pymodbus.client import AsyncModbusTcpClient
 
 # Default Configuration - matches real Alfen hardware
@@ -58,7 +60,7 @@ async def run_test(port):
         name = decode_string(rr.registers, 34)
         log.info(f"Product Name: '{name}'")
         if "Alfen" not in name:
-            log.error(f"Expected product name to contain 'Alfen'")
+            log.error("Expected product name to contain 'Alfen'")
             success = False
         else:
             log.info("✓ Product name verified")
@@ -110,7 +112,7 @@ async def run_test(port):
         
         # Verify voltages are in realistic range
         if not (220 < v_l1n < 245):
-            log.error(f"Voltage L1-N out of expected range (220-245V)")
+            log.error("Voltage L1-N out of expected range (220-245V)")
             success = False
         else:
             log.info("✓ Voltages verified")
@@ -198,7 +200,7 @@ def main():
     args = parser.parse_args()
     
     result = asyncio.run(run_test(args.port))
-    exit(0 if result else 1)
+    sys.exit(0 if result else 1)
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Fixes the 76 Ruff findings that were failing CI's lint workflow (the workflow itself was fixed in #51; this fixes the actual code).

**Mechanical (via \`ruff --fix\`):** import sorting, unused imports, \`Optional[X]\` → \`X | None\`, unused \`except ... as e\` bindings.

**Fixed by hand:**
- Narrowed several bare \`except Exception: pass\` blocks in \`__init__.py\` and \`simulator.py\` to \`(OSError, ModbusException)\` with debug logging instead of silently swallowing everything.
- Kept `_async_close()`'s handler and two other genuinely intentional broad catches (config_flow's connection test, simulator's best-effort ghost-process cleanup) as `except Exception`, marked `# noqa: BLE001` — narrowing those would drop real failure modes they need to catch (or, for `_async_close`, reintroduce the "unretrieved task exception" problem it exists to avoid).
- `config_flow.py`: simplified a boolean-returning if/else, combined a nested if, rewrote a generator as a set comprehension.
- `number.py`: `in dict.keys()` → `in dict`.
- `sensor.py`: combined a nested if.
- `debug_5020.py`: narrowed a bare `except:` to `except struct.error:` (the only thing `struct.unpack` raises there).
- `simulator.py`: added explicit `check=False` to `subprocess.run` calls (matches existing default, just explicit), parenthesized an implicit string concatenation, noqa'd a `datetime.now()` call that's intentionally naive (it simulates the charger's own local clock, not UTC).
- `smoke_test_ha.py`: switched `log.info(...)` calls from `%`-string-formatting to lazy logging args; put the previously-decoded-but-discarded `meter_age`/`meter_type` into the existing log+check pattern instead of throwing them away (verified against the simulator's actual register value before adding the range check).
- Replaced bare `exit()` with `sys.exit()` in three simulator scripts.

No intended behavior changes outside of what #52 already changed in `__init__.py`'s connection handling.